### PR TITLE
feat: consume RDS instance and cluster tags

### DIFF
--- a/extrds/cluster_discovery.go
+++ b/extrds/cluster_discovery.go
@@ -7,6 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
@@ -18,7 +21,6 @@ import (
 	"github.com/steadybit/extension-aws/utils"
 	"github.com/steadybit/extension-kit/extbuild"
 	"github.com/steadybit/extension-kit/extutil"
-	"time"
 )
 
 type rdsClusterDiscovery struct {
@@ -169,6 +171,11 @@ func toClusterTarget(dbCluster types.DBCluster, awsAccountNumber string, awsRegi
 	if dbCluster.MultiAZ != nil {
 		attributes["aws.rds.cluster.multi-az"] = []string{fmt.Sprintf("%t", *dbCluster.MultiAZ)}
 	}
+
+	for _, tag := range dbCluster.TagList {
+		attributes[fmt.Sprintf("aws.rds.cluster.label.%s", strings.ToLower(aws.ToString(tag.Key)))] = []string{aws.ToString(tag.Value)}
+	}
+
 	for _, member := range dbCluster.DBClusterMembers {
 		if member.IsClusterWriter == nil {
 			continue

--- a/extrds/cluster_discovery_test.go
+++ b/extrds/cluster_discovery_test.go
@@ -6,6 +6,7 @@ package extrds
 import (
 	"context"
 	"errors"
+
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/steadybit/discovery-kit/go/discovery_kit_api"
@@ -27,6 +28,9 @@ func TestGetAllRdsClusters(t *testing.T) {
 				Engine:              discovery_kit_api.Ptr("engine"),
 				Status:              discovery_kit_api.Ptr("status"),
 				MultiAZ:             discovery_kit_api.Ptr(true),
+				TagList: []types.Tag{
+					{Key: discovery_kit_api.Ptr("SpecialTag"), Value: discovery_kit_api.Ptr("Great Thing")},
+				},
 			},
 		},
 	}
@@ -43,11 +47,12 @@ func TestGetAllRdsClusters(t *testing.T) {
 	assert.Equal(t, rdsClusterTargetId, target.TargetType)
 	assert.Equal(t, "identifier", target.Label)
 	assert.Equal(t, "arn", target.Id)
-	assert.Equal(t, 8, len(target.Attributes))
+	assert.Equal(t, 9, len(target.Attributes))
 	assert.Equal(t, []string{"status"}, target.Attributes["aws.rds.cluster.status"])
 	assert.Equal(t, []string{"42"}, target.Attributes["aws.account"])
 	assert.Equal(t, []string{"us-east-1"}, target.Attributes["aws.region"])
 	assert.Equal(t, []string{"true"}, target.Attributes["aws.rds.cluster.multi-az"])
+	assert.Equal(t, []string{"Great Thing"}, target.Attributes["aws.rds.cluster.label.specialtag"])
 }
 
 func TestGetAllRdsClustersWithPagination(t *testing.T) {

--- a/extrds/instance_discovery.go
+++ b/extrds/instance_discovery.go
@@ -7,6 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
@@ -19,7 +22,6 @@ import (
 	"github.com/steadybit/extension-aws/utils"
 	"github.com/steadybit/extension-kit/extbuild"
 	"github.com/steadybit/extension-kit/extutil"
-	"time"
 )
 
 type rdsInstanceDiscovery struct {
@@ -147,6 +149,9 @@ func toInstanceTarget(dbInstance types.DBInstance, zoneUtil utils.GetZoneUtil, a
 
 	if dbInstance.DBClusterIdentifier != nil {
 		attributes["aws.rds.cluster"] = []string{aws.ToString(dbInstance.DBClusterIdentifier)}
+	}
+	for _, tag := range dbInstance.TagList {
+		attributes[fmt.Sprintf("aws.rds.label.%s", strings.ToLower(aws.ToString(tag.Key)))] = []string{aws.ToString(tag.Value)}
 	}
 
 	return discovery_kit_api.Target{


### PR DESCRIPTION
Just as with EC2 instances, consume tags from RDS instances and cluster resources.