### PR TITLE
feat: add ssm based attacks for fargate

### DIFF
--- a/extecs/task_attack_ssm.go
+++ b/extecs/task_attack_ssm.go
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2024 steadybit GmbH. All rights reserved.
+ */
+
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 Steadybit GmbH
+
+package extecs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/action-kit/go/action_kit_sdk"
+	"github.com/steadybit/extension-aws/utils"
+	extension_kit "github.com/steadybit/extension-kit"
+	"github.com/steadybit/extension-kit/extutil"
+	"time"
+)
+
+type ecsTaskSsmAction struct {
+	clientProvider       func(account string) (ecsTaskSsmApi, error)
+	description          action_kit_api.ActionDescription
+	ssmCommandInvocation ssmCommandInvocation
+}
+
+// Make sure lambdaAction implements all required interfaces
+var (
+	_ action_kit_sdk.ActionWithStop[TaskSsmActionState]   = (*ecsTaskSsmAction)(nil)
+	_ action_kit_sdk.ActionWithStatus[TaskSsmActionState] = (*ecsTaskSsmAction)(nil)
+
+	errorManagedInstanceNotFound  = errors.New("managed instance for ECS Task not found")
+	errorManagedInstanceAmbiguous = errors.New("found multiple managed instances for ECS Task")
+)
+
+type TaskSsmActionState struct {
+	Account           string
+	TaskArn           string
+	ManagedInstanceId string
+	CommandId         string
+	DocumentVersion   string
+	DocumentName      string
+	Parameters        map[string][]string
+	StepNameForStatus string
+	Comment           string
+}
+
+type ecsTaskSsmApi interface {
+	SendCommand(ctx context.Context, params *ssm.SendCommandInput, optFns ...func(*ssm.Options)) (*ssm.SendCommandOutput, error)
+	CancelCommand(ctx context.Context, params *ssm.CancelCommandInput, optFns ...func(*ssm.Options)) (*ssm.CancelCommandOutput, error)
+	DescribeInstanceInformation(ctx context.Context, params *ssm.DescribeInstanceInformationInput, optFns ...func(*ssm.Options)) (*ssm.DescribeInstanceInformationOutput, error)
+	ssm.GetCommandInvocationAPIClient
+}
+
+type ssmCommandInvocation struct {
+	documentVersion   string
+	documentName      string
+	getParameters     func(action_kit_api.PrepareActionRequestBody) (map[string][]string, error)
+	stepNameForStatus string
+}
+
+func newEcsTaskSsmAction(description func() action_kit_api.ActionDescription, invocation ssmCommandInvocation) action_kit_sdk.ActionWithStop[TaskSsmActionState] {
+	return &ecsTaskSsmAction{
+		clientProvider:       defaultTaskSsmClientProvider,
+		description:          description(),
+		ssmCommandInvocation: invocation,
+	}
+}
+
+func (e *ecsTaskSsmAction) NewEmptyState() TaskSsmActionState {
+	return TaskSsmActionState{}
+}
+
+func (e *ecsTaskSsmAction) Describe() action_kit_api.ActionDescription {
+	return e.description
+}
+
+func (e *ecsTaskSsmAction) Prepare(ctx context.Context, state *TaskSsmActionState, request action_kit_api.PrepareActionRequestBody) (*action_kit_api.PrepareResult, error) {
+	if account := request.Target.Attributes["aws.account"]; len(account) == 0 {
+		return nil, extension_kit.ToError("Target is missing the 'aws.account' attribute.", nil)
+	} else {
+		state.Account = account[0]
+	}
+
+	if taskArn := request.Target.Attributes["aws-ecs.task.arn"]; len(taskArn) == 0 {
+		return nil, extension_kit.ToError("Target is missing the 'aws-ecs.task.arn' attribute.", nil)
+	} else {
+		state.TaskArn = taskArn[0]
+	}
+
+	if managedInstanceId, err := e.findManagedInstance(ctx, state.Account, state.TaskArn); err != nil {
+		prepareErr := extension_kit.ToError(fmt.Sprintf("Failed to find managed instance for ECS Task %s", state.TaskArn), err)
+		if errors.Is(err, errorManagedInstanceNotFound) {
+			prepareErr.Detail = extutil.Ptr("Please make sure that the 'amazon-ssm-agent' is added to the task definition and running.")
+		}
+		return nil, prepareErr
+	} else {
+		state.ManagedInstanceId = managedInstanceId
+	}
+
+	if parameters, err := e.ssmCommandInvocation.getParameters(request); err != nil {
+		return nil, err
+	} else {
+		state.DocumentName = e.ssmCommandInvocation.documentName
+		state.DocumentVersion = e.ssmCommandInvocation.documentVersion
+		state.Parameters = parameters
+		state.StepNameForStatus = e.ssmCommandInvocation.stepNameForStatus
+		if request.ExecutionContext != nil && request.ExecutionContext.ExecutionId != nil && request.ExecutionContext.ExperimentKey != nil && request.ExecutionContext.ExecutionUri != nil {
+			state.Comment = fmt.Sprintf("Run by Steadybit for experiment %s #%d %s", *request.ExecutionContext.ExperimentKey, *request.ExecutionContext.ExecutionId, *request.ExecutionContext.ExecutionUri)
+		} else {
+			state.Comment = "Run by Steadybit"
+		}
+	}
+
+	return nil, nil
+}
+
+func (e *ecsTaskSsmAction) Start(ctx context.Context, state *TaskSsmActionState) (*action_kit_api.StartResult, error) {
+	client, err := e.clientProvider(state.Account)
+	if err != nil {
+		return nil, err
+	}
+
+	output, err := client.SendCommand(ctx, &ssm.SendCommandInput{
+		DocumentName:    &state.DocumentName,
+		DocumentVersion: &state.DocumentVersion,
+		InstanceIds:     []string{state.ManagedInstanceId},
+		Parameters:      state.Parameters,
+		Comment:         extutil.Ptr(state.Comment),
+		TimeoutSeconds:  extutil.Ptr(int32(30)),
+	})
+
+	if err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed start %s on ECS Task %s", e.description.Label, state.TaskArn), err)
+	} else {
+		state.CommandId = *output.Command.CommandId
+	}
+
+	return nil, nil
+}
+
+func (e *ecsTaskSsmAction) Status(ctx context.Context, state *TaskSsmActionState) (*action_kit_api.StatusResult, error) {
+	client, err := e.clientProvider(state.Account)
+	if err != nil {
+		return nil, err
+	}
+
+	output, err := client.GetCommandInvocation(ctx, e.createCommandInvocationInput(state))
+	if err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed get status for %s on ECS Task %s", e.description.Label, state.TaskArn), err)
+	}
+
+	if output.Status == types.CommandInvocationStatusSuccess ||
+		output.Status == types.CommandInvocationStatusFailed ||
+		output.Status == types.CommandInvocationStatusTimedOut ||
+		output.Status == types.CommandInvocationStatusCancelled {
+		return &action_kit_api.StatusResult{Completed: true}, nil
+	}
+
+	return nil, nil
+}
+
+func (e *ecsTaskSsmAction) createCommandInvocationInput(state *TaskSsmActionState) *ssm.GetCommandInvocationInput {
+	input := &ssm.GetCommandInvocationInput{
+		CommandId:  &state.CommandId,
+		InstanceId: &state.ManagedInstanceId,
+	}
+	if state.StepNameForStatus != "" {
+		input.PluginName = &state.StepNameForStatus
+	}
+	return input
+}
+
+func (e *ecsTaskSsmAction) Stop(ctx context.Context, state *TaskSsmActionState) (*action_kit_api.StopResult, error) {
+	client, err := e.clientProvider(state.Account)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = client.CancelCommand(ctx, &ssm.CancelCommandInput{
+		CommandId:   &state.CommandId,
+		InstanceIds: []string{state.ManagedInstanceId},
+	})
+	if err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to cancel %s on ECS Task %s", e.description.Label, state.TaskArn), err)
+	}
+
+	output, err := ssm.NewCommandExecutedWaiter(client).WaitForOutput(ctx, e.createCommandInvocationInput(state), 10*time.Second)
+	if err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to await end of %s on ECS Task %s", e.description.Label, state.TaskArn), err)
+	}
+
+	result := action_kit_api.StopResult{Messages: &[]action_kit_api.Message{}}
+	if output.Status != types.CommandInvocationStatusSuccess {
+		result.Error = &action_kit_api.ActionKitError{
+			Title: fmt.Sprintf("Ended %s on ECS Task %s with %s", e.description.Label, state.TaskArn, *output.StatusDetails),
+		}
+	}
+
+	result.Messages = extutil.Ptr(append(*result.Messages, action_kit_api.Message{
+		Level:   extutil.Ptr(action_kit_api.Info),
+		Message: fmt.Sprintf("%s(%s) RC=%d", *output.DocumentName, *output.DocumentVersion, output.ResponseCode),
+	}))
+	if output.StandardOutputContent != nil {
+		result.Messages = extutil.Ptr(append(*result.Messages, action_kit_api.Message{
+			Level:   extutil.Ptr(action_kit_api.Info),
+			Message: fmt.Sprintf("stdout:\n%s", *output.StandardOutputContent),
+		}))
+	}
+	if output.StandardErrorContent != nil {
+		result.Messages = extutil.Ptr(append(*result.Messages, action_kit_api.Message{
+			Level:   extutil.Ptr(action_kit_api.Error),
+			Message: fmt.Sprintf("stderr:\n%s", *output.StandardErrorContent),
+		}))
+	}
+
+	return &result, nil
+}
+
+func (e *ecsTaskSsmAction) findManagedInstance(ctx context.Context, account, taskArn string) (string, error) {
+	client, err := e.clientProvider(account)
+	if err != nil {
+		return "", extension_kit.ToError(fmt.Sprintf("Failed to initialize ECS client for AWS account %s", account), err)
+	}
+
+	output, err := client.DescribeInstanceInformation(ctx, &ssm.DescribeInstanceInformationInput{
+		Filters: []types.InstanceInformationStringFilter{
+			{Key: extutil.Ptr("tag:ECS_TASK_ARN"), Values: []string{taskArn}},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if len(output.InstanceInformationList) == 1 && output.InstanceInformationList[0].InstanceId != nil {
+		return *output.InstanceInformationList[0].InstanceId, nil
+	} else if len(output.InstanceInformationList) > 1 {
+		return "", errorManagedInstanceAmbiguous
+	} else {
+		return "", errorManagedInstanceNotFound
+	}
+}
+
+func defaultTaskSsmClientProvider(account string) (ecsTaskSsmApi, error) {
+	awsAccount, err := utils.Accounts.GetAccount(account)
+	if err != nil {
+		return nil, err
+	}
+	return ssm.NewFromConfig(awsAccount.AwsConfig), nil
+}

--- a/extecs/task_attack_ssm_cpu.go
+++ b/extecs/task_attack_ssm_cpu.go
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 steadybit GmbH. All rights reserved.
+ */
+
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2024 Steadybit GmbH
+
+package extecs
+
+import (
+	"fmt"
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/action-kit/go/action_kit_sdk"
+	"github.com/steadybit/extension-kit/extbuild"
+	"github.com/steadybit/extension-kit/extutil"
+	"strconv"
+	"time"
+)
+
+func NewEcsTaskStressCpuAction() action_kit_sdk.Action[TaskSsmActionState] {
+	return newEcsTaskSsmAction(getEcsTaskStressCpuDescription, ssmCommandInvocation{
+		documentName:      "AWSFIS-Run-CPU-Stress",
+		documentVersion:   "12",
+		stepNameForStatus: "ExecuteStressNg",
+		getParameters:     getEcsTaskStressCpuParameters,
+	})
+}
+
+func getEcsTaskStressCpuParameters(request action_kit_api.PrepareActionRequestBody) (map[string][]string, error) {
+	duration := time.Duration(extutil.ToInt64(request.Config["duration"])) * time.Millisecond
+
+	return map[string][]string{
+		"DurationSeconds": {fmt.Sprintf("%d", int64(duration.Seconds()))},
+		"CPU":             {strconv.Itoa(extutil.ToInt(request.Config["workers"]))},
+		"LoadPercent":     {strconv.Itoa(extutil.ToInt(request.Config["cpuLoad"]))},
+	}, nil
+}
+
+func getEcsTaskStressCpuDescription() action_kit_api.ActionDescription {
+	return action_kit_api.ActionDescription{
+		Id:          fmt.Sprintf("%s.stress_cpu", ecsTaskTargetId),
+		Label:       "Stress CPU",
+		Description: "Stresses CPU for the given duration.",
+		Version:     extbuild.GetSemverVersionStringOrUnknown(),
+		Icon:        extutil.Ptr(ecsTaskIcon),
+		TargetSelection: &action_kit_api.TargetSelection{
+			TargetType: ecsTaskTargetId,
+			SelectionTemplates: extutil.Ptr([]action_kit_api.TargetSelectionTemplate{
+				{
+					Label:       "by service and cluster",
+					Description: extutil.Ptr("Find ecs task by cluster and service name"),
+					Query:       "aws-ecs.cluster.name=\"\" and aws-ecs.service.name=\"\" and aws-ecs.task.amazon-ssm-agent=\"true\"",
+				},
+			}),
+		},
+		Category:    extutil.Ptr("resource"),
+		Kind:        action_kit_api.Attack,
+		TimeControl: action_kit_api.TimeControlExternal,
+		Parameters: []action_kit_api.ActionParameter{
+			{
+				Name:         "cpuLoad",
+				Label:        "Load on Container CPU",
+				Description:  extutil.Ptr("How much CPU load should be inflicted?"),
+				Type:         action_kit_api.Percentage,
+				DefaultValue: extutil.Ptr("100"),
+				Required:     extutil.Ptr(true),
+				Order:        extutil.Ptr(0),
+				MinValue:     extutil.Ptr(1),
+				MaxValue:     extutil.Ptr(100),
+			},
+			{
+				Name:         "workers",
+				Label:        "Container CPUs",
+				Description:  extutil.Ptr("How many workers should be used to stress the CPU?"),
+				Type:         action_kit_api.StressngWorkers,
+				DefaultValue: extutil.Ptr("0"),
+				Required:     extutil.Ptr(true),
+				Order:        extutil.Ptr(1),
+			},
+			{
+				Name:         "duration",
+				Label:        "Duration",
+				Description:  extutil.Ptr("How long should the CPU be stressed?"),
+				Type:         action_kit_api.Duration,
+				DefaultValue: extutil.Ptr("30s"),
+				Required:     extutil.Ptr(true),
+				Order:        extutil.Ptr(2),
+			},
+		},
+	}
+}

--- a/extecs/task_attack_ssm_fill_disk.go
+++ b/extecs/task_attack_ssm_fill_disk.go
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 steadybit GmbH. All rights reserved.
+ */
+
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2024 Steadybit GmbH
+
+package extecs
+
+import (
+	"fmt"
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/action-kit/go/action_kit_sdk"
+	"github.com/steadybit/extension-kit/extbuild"
+	"github.com/steadybit/extension-kit/extutil"
+	"strconv"
+	"time"
+)
+
+func NewEcsTaskFillDiskAction() action_kit_sdk.Action[TaskSsmActionState] {
+	return newEcsTaskSsmAction(getEcsTaskFillDiskDescription, ssmCommandInvocation{
+		documentName:      "AWSFIS-Run-Disk-Fill",
+		documentVersion:   "8",
+		stepNameForStatus: "ExecuteStressNg",
+		getParameters:     getEcsTaskFillDiskParameters,
+	})
+}
+
+func getEcsTaskFillDiskParameters(request action_kit_api.PrepareActionRequestBody) (map[string][]string, error) {
+	duration := time.Duration(extutil.ToInt64(request.Config["duration"])) * time.Millisecond
+
+	return map[string][]string{
+		"DurationSeconds": {fmt.Sprintf("%d", int64(duration.Seconds()))},
+		"Percent":         {strconv.Itoa(extutil.ToInt(request.Config["percent"]))},
+	}, nil
+}
+
+func getEcsTaskFillDiskDescription() action_kit_api.ActionDescription {
+	return action_kit_api.ActionDescription{
+		Id:          fmt.Sprintf("%s.fill_disk", ecsTaskTargetId),
+		Label:       "Fill Disk",
+		Description: "Fill Disk for the given duration.",
+		Version:     extbuild.GetSemverVersionStringOrUnknown(),
+		Icon:        extutil.Ptr(ecsTaskIcon),
+		TargetSelection: &action_kit_api.TargetSelection{
+			TargetType: ecsTaskTargetId,
+			SelectionTemplates: extutil.Ptr([]action_kit_api.TargetSelectionTemplate{
+				{
+					Label:       "by service and cluster",
+					Description: extutil.Ptr("Find ecs task by cluster and service name"),
+					Query:       "aws-ecs.cluster.name=\"\" and aws-ecs.service.name=\"\" and aws-ecs.task.amazon-ssm-agent=\"true\"",
+				},
+			}),
+		},
+		Category:    extutil.Ptr("resource"),
+		Kind:        action_kit_api.Attack,
+		TimeControl: action_kit_api.TimeControlExternal,
+		Parameters: []action_kit_api.ActionParameter{
+			{
+				Name:         "percent",
+				Label:        "Fill Percentage",
+				Description:  extutil.Ptr("How many the percent of the allocated disk space dependent on the total available size shall be filled?"),
+				Type:         action_kit_api.Percentage,
+				DefaultValue: extutil.Ptr("100"),
+				Required:     extutil.Ptr(true),
+				Order:        extutil.Ptr(0),
+				MinValue:     extutil.Ptr(1),
+				MaxValue:     extutil.Ptr(100),
+			},
+			{
+				Name:         "duration",
+				Label:        "Duration",
+				Description:  extutil.Ptr("How long should the disk be filled?"),
+				Type:         action_kit_api.Duration,
+				DefaultValue: extutil.Ptr("30s"),
+				Required:     extutil.Ptr(true),
+				Order:        extutil.Ptr(2),
+			},
+		},
+	}
+}

--- a/extecs/task_attack_ssm_io.go
+++ b/extecs/task_attack_ssm_io.go
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 steadybit GmbH. All rights reserved.
+ */
+
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2024 Steadybit GmbH
+
+package extecs
+
+import (
+	"fmt"
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/action-kit/go/action_kit_sdk"
+	"github.com/steadybit/extension-kit/extbuild"
+	"github.com/steadybit/extension-kit/extutil"
+	"strconv"
+	"time"
+)
+
+func NewEcsTaskStressIoAction() action_kit_sdk.Action[TaskSsmActionState] {
+	return newEcsTaskSsmAction(getEcsTaskStressIoDescription, ssmCommandInvocation{
+		documentName:      "AWSFIS-Run-IO-Stress",
+		documentVersion:   "11",
+		stepNameForStatus: "ExecuteStressNg",
+		getParameters:     getEcsTaskStressIoParameters,
+	})
+}
+
+func getEcsTaskStressIoParameters(request action_kit_api.PrepareActionRequestBody) (map[string][]string, error) {
+	duration := time.Duration(extutil.ToInt64(request.Config["duration"])) * time.Millisecond
+
+	return map[string][]string{
+		"DurationSeconds": {fmt.Sprintf("%d", int64(duration.Seconds()))},
+		"Workers":         {strconv.Itoa(extutil.ToInt(request.Config["workers"]))},
+		"Percent":         {strconv.Itoa(extutil.ToInt(request.Config["percent"]))},
+	}, nil
+}
+
+func getEcsTaskStressIoDescription() action_kit_api.ActionDescription {
+	return action_kit_api.ActionDescription{
+		Id:          fmt.Sprintf("%s.stress_io", ecsTaskTargetId),
+		Label:       "Stress IO",
+		Description: "Stresses IO for the given duration.",
+		Version:     extbuild.GetSemverVersionStringOrUnknown(),
+		Icon:        extutil.Ptr(ecsTaskIcon),
+		TargetSelection: &action_kit_api.TargetSelection{
+			TargetType: ecsTaskTargetId,
+			SelectionTemplates: extutil.Ptr([]action_kit_api.TargetSelectionTemplate{
+				{
+					Label:       "by service and cluster",
+					Description: extutil.Ptr("Find ecs task by cluster and service name"),
+					Query:       "aws-ecs.cluster.name=\"\" and aws-ecs.service.name=\"\" and aws-ecs.task.amazon-ssm-agent=\"true\"",
+				},
+			}),
+		},
+		Category:    extutil.Ptr("resource"),
+		Kind:        action_kit_api.Attack,
+		TimeControl: action_kit_api.TimeControlExternal,
+		Parameters: []action_kit_api.ActionParameter{
+			{
+				Name:         "percent",
+				Label:        "Disk Space Percentage",
+				Description:  extutil.Ptr("How many the percent of the available file system space shall be used by each worker?"),
+				Type:         action_kit_api.Percentage,
+				DefaultValue: extutil.Ptr("100"),
+				Required:     extutil.Ptr(true),
+				Order:        extutil.Ptr(0),
+				MinValue:     extutil.Ptr(1),
+				MaxValue:     extutil.Ptr(100),
+			},
+			{
+				Name:         "workers",
+				Label:        "Workers",
+				Description:  extutil.Ptr("How many workers should stress the IO?"),
+				Type:         action_kit_api.StressngWorkers,
+				DefaultValue: extutil.Ptr("1"),
+				Required:     extutil.Ptr(true),
+				Order:        extutil.Ptr(1),
+			},
+			{
+				Name:         "duration",
+				Label:        "Duration",
+				Description:  extutil.Ptr("How long should the IO be stressed?"),
+				Type:         action_kit_api.Duration,
+				DefaultValue: extutil.Ptr("30s"),
+				Required:     extutil.Ptr(true),
+				Order:        extutil.Ptr(2),
+			},
+		},
+	}
+}

--- a/extecs/task_attack_ssm_memory.go
+++ b/extecs/task_attack_ssm_memory.go
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 steadybit GmbH. All rights reserved.
+ */
+
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2024 Steadybit GmbH
+
+package extecs
+
+import (
+	"fmt"
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/action-kit/go/action_kit_sdk"
+	"github.com/steadybit/extension-kit/extbuild"
+	"github.com/steadybit/extension-kit/extutil"
+	"strconv"
+	"time"
+)
+
+func NewEcsTaskStressMemoryAction() action_kit_sdk.Action[TaskSsmActionState] {
+	return newEcsTaskSsmAction(getEcsTaskStressMemoryDescription, ssmCommandInvocation{
+		documentName:      "AWSFIS-Run-Memory-Stress",
+		documentVersion:   "13",
+		stepNameForStatus: "ExecuteStressNg",
+		getParameters:     getEcsTaskStressMemoryParameters,
+	})
+}
+
+func getEcsTaskStressMemoryParameters(request action_kit_api.PrepareActionRequestBody) (map[string][]string, error) {
+	duration := time.Duration(extutil.ToInt64(request.Config["duration"])) * time.Millisecond
+
+	return map[string][]string{
+		"DurationSeconds": {fmt.Sprintf("%d", int64(duration.Seconds()))},
+		"Workers":         {strconv.Itoa(extutil.ToInt(request.Config["workers"]))},
+		"Percent":         {strconv.Itoa(extutil.ToInt(request.Config["percent"]))},
+	}, nil
+}
+
+func getEcsTaskStressMemoryDescription() action_kit_api.ActionDescription {
+	return action_kit_api.ActionDescription{
+		Id:          fmt.Sprintf("%s.stress_mem", ecsTaskTargetId),
+		Label:       "Stress Memory",
+		Description: "Stresses Memory for the given duration.",
+		Version:     extbuild.GetSemverVersionStringOrUnknown(),
+		Icon:        extutil.Ptr(ecsTaskIcon),
+		TargetSelection: &action_kit_api.TargetSelection{
+			TargetType: ecsTaskTargetId,
+			SelectionTemplates: extutil.Ptr([]action_kit_api.TargetSelectionTemplate{
+				{
+					Label:       "by service and cluster",
+					Description: extutil.Ptr("Find ecs task by cluster and service name"),
+					Query:       "aws-ecs.cluster.name=\"\" and aws-ecs.service.name=\"\" and aws-ecs.task.amazon-ssm-agent=\"true\"",
+				},
+			}),
+		},
+		Category:    extutil.Ptr("resource"),
+		Kind:        action_kit_api.Attack,
+		TimeControl: action_kit_api.TimeControlExternal,
+		Parameters: []action_kit_api.ActionParameter{
+			{
+				Name:         "percent",
+				Label:        "Memory Percentage",
+				Description:  extutil.Ptr("How many the percent of the available virtual memory shall be used?"),
+				Type:         action_kit_api.Percentage,
+				DefaultValue: extutil.Ptr("100"),
+				Required:     extutil.Ptr(true),
+				Order:        extutil.Ptr(0),
+				MinValue:     extutil.Ptr(1),
+				MaxValue:     extutil.Ptr(100),
+			},
+			{
+				Name:         "workers",
+				Label:        "Workers",
+				Description:  extutil.Ptr("How many workers should stress the memory?"),
+				Type:         action_kit_api.StressngWorkers,
+				DefaultValue: extutil.Ptr("1"),
+				Required:     extutil.Ptr(true),
+				Order:        extutil.Ptr(1),
+			},
+			{
+				Name:         "duration",
+				Label:        "Duration",
+				Description:  extutil.Ptr("How long should the memory be stressed?"),
+				Type:         action_kit_api.Duration,
+				DefaultValue: extutil.Ptr("30s"),
+				Required:     extutil.Ptr(true),
+				Order:        extutil.Ptr(2),
+			},
+		},
+	}
+}

--- a/extecs/task_attack_stop.go
+++ b/extecs/task_attack_stop.go
@@ -33,7 +33,7 @@ type ecsTaskStopApi interface {
 }
 
 func NewEcsTaskStopAction() action_kit_sdk.Action[TaskStopState] {
-	return &ecsTaskStopAction{defaultClientProvider}
+	return &ecsTaskStopAction{defaultTaskStopClientProvider}
 }
 
 func (e *ecsTaskStopAction) NewEmptyState() TaskStopState {
@@ -92,7 +92,7 @@ func (e *ecsTaskStopAction) Start(ctx context.Context, state *TaskStopState) (*a
 	return nil, nil
 }
 
-func defaultClientProvider(account string) (ecsTaskStopApi, error) {
+func defaultTaskStopClientProvider(account string) (ecsTaskStopApi, error) {
 	awsAccount, err := utils.Accounts.GetAccount(account)
 	if err != nil {
 		return nil, err

--- a/extecs/task_discovery_test.go
+++ b/extecs/task_discovery_test.go
@@ -65,6 +65,11 @@ var task = types.Task{
 		{Key: extutil.Ptr("aws:ecs:serviceName"), Value: extutil.Ptr("ecs-demo-gateway-service")},
 		{Key: extutil.Ptr("test"), Value: extutil.Ptr("123")},
 	},
+	Containers: []types.Container{
+		{
+			Image: extutil.Ptr("public.ecr.aws/amazon-ssm-agent/amazon-ssm-agent:latest"),
+		},
+	},
 }
 var taskArn2 = "arn:aws:ecs:eu-central-1:42:task/sandbox-demo-ecs-fargate/15ac9bc28dce4a6fb757580ac87eb855"
 var taskStopped = types.Task{
@@ -120,4 +125,5 @@ func TestGetAllEcsTasks(t *testing.T) {
 	assert.Equal(t, []string{"ecs-demo-gateway-service"}, target.Attributes["aws-ecs.service.name"])
 	assert.Equal(t, []string{"sandbox-demo-ecs-fargate"}, target.Attributes["aws-ecs.cluster.name"])
 	assert.Equal(t, []string{"FARGATE"}, target.Attributes["aws-ecs.task.launch-type"])
+	assert.Equal(t, []string{"true"}, target.Attributes["aws-ecs.task.amazon-ssm-agent"])
 }

--- a/main.go
+++ b/main.go
@@ -117,6 +117,10 @@ func registerHandlers(ctx context.Context) {
 		discovery_kit_sdk.Register(extecs.NewEcsServiceDiscovery(ctx))
 		action_kit_sdk.RegisterAction(extecs.NewEcsTaskStopAction())
 		action_kit_sdk.RegisterAction(extecs.NewEcsServiceScaleAction())
+		action_kit_sdk.RegisterAction(extecs.NewEcsTaskStressCpuAction())
+		action_kit_sdk.RegisterAction(extecs.NewEcsTaskStressMemoryAction())
+		action_kit_sdk.RegisterAction(extecs.NewEcsTaskStressIoAction())
+		action_kit_sdk.RegisterAction(extecs.NewEcsTaskFillDiskAction())
 	}
 
 	exthttp.RegisterHttpHandler("/", exthttp.GetterAsHandler(getExtensionList))

--- a/main_test.go
+++ b/main_test.go
@@ -57,6 +57,10 @@ func Test_getExtensionList(t *testing.T) {
 			wantedRoutes: []string{
 				"/com.steadybit.extension_aws.ecs-task.stop",
 				"/com.steadybit.extension_aws.ecs-service.scale",
+				"/com.steadybit.extension_aws.ecs-task.fill_disk",
+				"/com.steadybit.extension_aws.ecs-task.stress_cpu",
+				"/com.steadybit.extension_aws.ecs-task.stress_mem",
+				"/com.steadybit.extension_aws.ecs-task.stress_io",
 				"/com.steadybit.extension_aws.ecs-task/discovery",
 				"/com.steadybit.extension_aws.ecs-task/discovery/target-description",
 				"/com.steadybit.extension_aws.ecs-service/discovery",


### PR DESCRIPTION
this adds attacks carried out using the ssm agent added to fargate tasks.
These attacks include:
 - fill disk
 - stress memory
 - stress io
 - stress cpu