### PR TITLE
feat(apigateway): support throttle attack on HTTP APIs (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ by tweaking the `Resource` clause.
 }
 ```
 
-> Note: API Gateway uses the `apigateway:GET`/`apigateway:PATCH` style of permissions instead of dedicated action verbs. `PATCH` is only required if you want to use the throttle attack on REST stages; otherwise, only `GET` is needed.
+> Note: API Gateway uses the `apigateway:GET`/`apigateway:PATCH` style of permissions instead of dedicated action verbs. `GET` covers discovery of both REST (v1) and HTTP (v2) APIs. `PATCH` is required if you want to use the throttle attack on either REST or HTTP stages (a single IAM action covers both API types). WebSocket stages are not supported by the throttle attack.
 
 </details>
 <details>

--- a/charts/steadybit-extension-aws/Chart.yaml
+++ b/charts/steadybit-extension-aws/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-extension-aws
 description: Steadybit AWS extension Helm chart for Kubernetes.
-version: 2.2.21
+version: 2.3.1
 appVersion: v2.4.14
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-extension-aws/Chart.yaml
+++ b/charts/steadybit-extension-aws/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-extension-aws
 description: Steadybit AWS extension Helm chart for Kubernetes.
-version: 2.3.1
+version: 2.2.22
 appVersion: v2.4.14
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/extapigateway/common.go
+++ b/extapigateway/common.go
@@ -16,18 +16,31 @@ const (
 	stageTargetType = "com.steadybit.extension_aws.apigateway.stage"
 )
 
-// ApiGatewayStageThrottleAttackState captures the throttle config of a REST stage so we can restore it on stop.
+// ApiGatewayStageThrottleAttackState captures the throttle config of an API Gateway stage so we can restore
+// it on stop. The same state struct serves both REST (v1) and HTTP (v2) stages — ProtocolType drives the
+// branching in Prepare/Start/Stop.
 type ApiGatewayStageThrottleAttackState struct {
-	ApiId                       string
-	StageName                   string
-	Account                     string
-	Region                      string
-	DiscoveredByRole            *string
+	ApiId            string
+	StageName        string
+	Account          string
+	Region           string
+	ProtocolType     string // "REST" or "HTTP"
+	DiscoveredByRole *string
+
+	// Target values (apply to both REST and HTTP).
+	TargetRateLimit  float64
+	TargetBurstLimit int32
+
+	// REST snapshot: pulled from Stage.MethodSettings["*/*"]. HadOriginalThrottleSettings=false means we
+	// remove the override on Stop so the stage falls back to account defaults.
 	OriginalRateLimit           float64
 	OriginalBurstLimit          int32
 	HadOriginalThrottleSettings bool
-	TargetRateLimit             float64
-	TargetBurstLimit            int32
+
+	// HTTP snapshot: full Stage.DefaultRouteSettings serialised as JSON so we can restore non-throttle
+	// fields (DataTraceEnabled, DetailedMetricsEnabled, LoggingLevel) verbatim. Empty string means
+	// DefaultRouteSettings was nil; on Stop we send an empty RouteSettings to clear what we set.
+	HttpOrigDefaultRouteSettings string
 }
 
 type RestApiGatewayApi interface {
@@ -40,6 +53,8 @@ type RestApiGatewayApi interface {
 type HttpApiGatewayApi interface {
 	GetApis(ctx context.Context, params *apigatewayv2.GetApisInput, optFns ...func(*apigatewayv2.Options)) (*apigatewayv2.GetApisOutput, error)
 	GetStages(ctx context.Context, params *apigatewayv2.GetStagesInput, optFns ...func(*apigatewayv2.Options)) (*apigatewayv2.GetStagesOutput, error)
+	GetStage(ctx context.Context, params *apigatewayv2.GetStageInput, optFns ...func(*apigatewayv2.Options)) (*apigatewayv2.GetStageOutput, error)
+	UpdateStage(ctx context.Context, params *apigatewayv2.UpdateStageInput, optFns ...func(*apigatewayv2.Options)) (*apigatewayv2.UpdateStageOutput, error)
 }
 
 func defaultRestClientProvider(account string, region string, role *string) (RestApiGatewayApi, error) {

--- a/extapigateway/common.go
+++ b/extapigateway/common.go
@@ -31,11 +31,18 @@ type ApiGatewayStageThrottleAttackState struct {
 	TargetRateLimit  float64
 	TargetBurstLimit int32
 
-	// REST snapshot: pulled from Stage.MethodSettings["*/*"]. HadOriginalThrottleSettings=false means we
-	// remove the override on Stop so the stage falls back to account defaults.
+	// REST snapshot pulled from Stage.MethodSettings["*/*"]. Three cases drive the Stop restore:
+	//   - HadOriginalThrottleSettings=true → replace throttle fields with the captured values.
+	//   - HadOriginalThrottleSettings=false && RestStageHadMethodSetting=true → reset throttle to
+	//     account defaults via op=replace value=-1, preserving other MethodSetting fields (caching,
+	//     metrics, logging).
+	//   - RestStageHadMethodSetting=false → op=remove path=/*/* to delete the MethodSetting our Start
+	//     implicitly created. AWS does not support op=remove on individual property paths under a
+	//     MethodSetting, so the per-field remove that was here previously erroneously failed.
 	OriginalRateLimit           float64
 	OriginalBurstLimit          int32
 	HadOriginalThrottleSettings bool
+	RestStageHadMethodSetting   bool
 
 	// HTTP snapshot: full Stage.DefaultRouteSettings serialised as JSON so we can restore non-throttle
 	// fields (DataTraceEnabled, DetailedMetricsEnabled, LoggingLevel) verbatim. Empty string means

--- a/extapigateway/stage_attack_throttle.go
+++ b/extapigateway/stage_attack_throttle.go
@@ -150,9 +150,16 @@ func (a *stageThrottleAttack) prepareRest(ctx context.Context, state *ApiGateway
 		return extension_kit.ToError(fmt.Sprintf("Failed to describe API Gateway stage %s/%s", state.ApiId, state.StageName), err)
 	}
 	if ms, ok := stageOut.MethodSettings["*/*"]; ok {
-		state.HadOriginalThrottleSettings = true
-		state.OriginalRateLimit = ms.ThrottlingRateLimit
-		state.OriginalBurstLimit = ms.ThrottlingBurstLimit
+		state.RestStageHadMethodSetting = true
+		// The AWS Go SDK uses non-pointer fields for ThrottlingRateLimit/BurstLimit, so an unset throttle
+		// returns as zero. A literal 0 throttle is pathological (locks the stage to no traffic) and
+		// indistinguishable here from "unset"; treat any positive value as set, otherwise fall through to
+		// the "reset to account default" branch on Stop. AWS reports the unset sentinel as -1 too.
+		if ms.ThrottlingRateLimit > 0 || ms.ThrottlingBurstLimit > 0 {
+			state.HadOriginalThrottleSettings = true
+			state.OriginalRateLimit = ms.ThrottlingRateLimit
+			state.OriginalBurstLimit = ms.ThrottlingBurstLimit
+		}
 	}
 	return nil
 }
@@ -280,18 +287,28 @@ func (a *stageThrottleAttack) stopRest(ctx context.Context, state *ApiGatewaySta
 	if err != nil {
 		return extension_kit.ToError(fmt.Sprintf("Failed to initialize API Gateway client for AWS account %s", state.Account), err)
 	}
-	patches := make([]apigwtypes.PatchOperation, 0, 2)
-	if state.HadOriginalThrottleSettings {
-		patches = append(patches,
-			apigwtypes.PatchOperation{Op: apigwtypes.OpReplace, Path: aws.String("/*/*/throttling/rateLimit"), Value: aws.String(strconv.FormatFloat(state.OriginalRateLimit, 'f', -1, 64))},
-			apigwtypes.PatchOperation{Op: apigwtypes.OpReplace, Path: aws.String("/*/*/throttling/burstLimit"), Value: aws.String(strconv.Itoa(int(state.OriginalBurstLimit)))},
-		)
-	} else {
-		// Stage had no */* throttle override before; remove the ones we added so the stage falls back to account-level defaults.
-		patches = append(patches,
-			apigwtypes.PatchOperation{Op: apigwtypes.OpRemove, Path: aws.String("/*/*/throttling/rateLimit")},
-			apigwtypes.PatchOperation{Op: apigwtypes.OpRemove, Path: aws.String("/*/*/throttling/burstLimit")},
-		)
+	var patches []apigwtypes.PatchOperation
+	switch {
+	case state.HadOriginalThrottleSettings:
+		// Throttle was set on */* before our attack — restore the captured values.
+		patches = []apigwtypes.PatchOperation{
+			{Op: apigwtypes.OpReplace, Path: aws.String("/*/*/throttling/rateLimit"), Value: aws.String(strconv.FormatFloat(state.OriginalRateLimit, 'f', -1, 64))},
+			{Op: apigwtypes.OpReplace, Path: aws.String("/*/*/throttling/burstLimit"), Value: aws.String(strconv.Itoa(int(state.OriginalBurstLimit)))},
+		}
+	case state.RestStageHadMethodSetting:
+		// */* MethodSetting existed (caching, metrics, etc.) but throttle was not set; reset throttle
+		// to account-default via value=-1 while preserving the rest of the MethodSetting fields.
+		patches = []apigwtypes.PatchOperation{
+			{Op: apigwtypes.OpReplace, Path: aws.String("/*/*/throttling/rateLimit"), Value: aws.String("-1")},
+			{Op: apigwtypes.OpReplace, Path: aws.String("/*/*/throttling/burstLimit"), Value: aws.String("-1")},
+		}
+	default:
+		// */* MethodSetting did not exist before our Start; remove the one our Start implicitly created.
+		// AWS only accepts remove at the MethodSetting level — op=remove on /*/*/throttling/rateLimit
+		// errors with "Cannot remove method setting ... because there is no method setting for this method".
+		patches = []apigwtypes.PatchOperation{
+			{Op: apigwtypes.OpRemove, Path: aws.String("/*/*")},
+		}
 	}
 	_, err = client.UpdateStage(ctx, &apigateway.UpdateStageInput{
 		RestApiId:       aws.String(state.ApiId),

--- a/extapigateway/stage_attack_throttle.go
+++ b/extapigateway/stage_attack_throttle.go
@@ -5,12 +5,15 @@ package extapigateway
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	apigwtypes "github.com/aws/aws-sdk-go-v2/service/apigateway/types"
+	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
+	apigwv2types "github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
 	"github.com/rs/zerolog/log"
 	"github.com/steadybit/action-kit/go/action_kit_api/v2"
 	"github.com/steadybit/action-kit/go/action_kit_sdk"
@@ -21,7 +24,8 @@ import (
 )
 
 type stageThrottleAttack struct {
-	clientProvider func(account string, region string, role *string) (RestApiGatewayApi, error)
+	restClientProvider func(account string, region string, role *string) (RestApiGatewayApi, error)
+	httpClientProvider func(account string, region string, role *string) (HttpApiGatewayApi, error)
 }
 
 var (
@@ -30,7 +34,10 @@ var (
 )
 
 func NewStageThrottleAttack() action_kit_sdk.ActionWithStop[ApiGatewayStageThrottleAttackState] {
-	return &stageThrottleAttack{clientProvider: defaultRestClientProvider}
+	return &stageThrottleAttack{
+		restClientProvider: defaultRestClientProvider,
+		httpClientProvider: defaultHttpClientProvider,
+	}
 }
 
 func (a *stageThrottleAttack) NewEmptyState() ApiGatewayStageThrottleAttackState {
@@ -39,11 +46,12 @@ func (a *stageThrottleAttack) NewEmptyState() ApiGatewayStageThrottleAttackState
 
 func (a *stageThrottleAttack) Describe() action_kit_api.ActionDescription {
 	return action_kit_api.ActionDescription{
-		Id:          fmt.Sprintf("%s.throttle", stageTargetType),
-		Label:       "Throttle API Gateway stage (REST)",
-		Description: "Lowers the stage-level throttle rate and burst limits for the duration of the experiment to simulate API throttling. Original limits are restored on stop. Supported on REST APIs only.",
-		Version:     extbuild.GetSemverVersionStringOrUnknown(),
-		Icon:        new(apiGatewayIcon),
+		Id:    fmt.Sprintf("%s.throttle", stageTargetType),
+		Label: "Throttle API Gateway stage",
+		Description: "Lowers the stage-level throttle rate and burst limits for the duration of the experiment to simulate API throttling. " +
+			"Original limits are restored on stop. Supports REST APIs (v1) and HTTP APIs (v2); WebSocket APIs are not supported.",
+		Version: extbuild.GetSemverVersionStringOrUnknown(),
+		Icon:    new(apiGatewayIcon),
 		TargetSelection: new(action_kit_api.TargetSelection{
 			TargetType: stageTargetType,
 			SelectionTemplates: new([]action_kit_api.TargetSelectionTemplate{
@@ -51,6 +59,11 @@ func (a *stageThrottleAttack) Describe() action_kit_api.ActionDescription {
 					Label:       "by API id and stage (REST)",
 					Description: new("Find REST API stage by API id and stage name"),
 					Query:       "aws.apigateway.api.protocol-type=\"REST\" and aws.apigateway.api.id=\"\" and aws.apigateway.stage.name=\"\"",
+				},
+				{
+					Label:       "by API id and stage (HTTP)",
+					Description: new("Find HTTP API stage by API id and stage name"),
+					Query:       "aws.apigateway.api.protocol-type=\"HTTP\" and aws.apigateway.api.id=\"\" and aws.apigateway.stage.name=\"\"",
 				},
 			}),
 		}),
@@ -99,8 +112,12 @@ func (a *stageThrottleAttack) Prepare(ctx context.Context, state *ApiGatewayStag
 	state.DiscoveredByRole = utils.GetOptionalTargetAttribute(request.Target.Attributes, "extension-aws.discovered-by-role")
 
 	protocols := request.Target.Attributes["aws.apigateway.api.protocol-type"]
-	if len(protocols) == 0 || protocols[0] != protocolREST {
-		return nil, extension_kit.ToError("Throttle attack is supported on REST API stages only.", nil)
+	if len(protocols) == 0 {
+		return nil, extension_kit.ToError("Target is missing aws.apigateway.api.protocol-type attribute.", nil)
+	}
+	state.ProtocolType = protocols[0]
+	if state.ProtocolType != protocolREST && state.ProtocolType != protocolHTTP {
+		return nil, extension_kit.ToError(fmt.Sprintf("Throttle attack does not support protocol-type %q. Supported: REST, HTTP.", state.ProtocolType), nil)
 	}
 
 	rateLimit := extutil.ToInt(request.Config["rateLimit"])
@@ -111,29 +128,96 @@ func (a *stageThrottleAttack) Prepare(ctx context.Context, state *ApiGatewayStag
 	state.TargetRateLimit = float64(rateLimit)
 	state.TargetBurstLimit = int32(burstLimit)
 
-	client, err := a.clientProvider(state.Account, state.Region, state.DiscoveredByRole)
+	switch state.ProtocolType {
+	case protocolREST:
+		return nil, a.prepareRest(ctx, state)
+	case protocolHTTP:
+		return nil, a.prepareHttp(ctx, state)
+	}
+	return nil, nil
+}
+
+func (a *stageThrottleAttack) prepareRest(ctx context.Context, state *ApiGatewayStageThrottleAttackState) error {
+	client, err := a.restClientProvider(state.Account, state.Region, state.DiscoveredByRole)
 	if err != nil {
-		return nil, extension_kit.ToError(fmt.Sprintf("Failed to initialize API Gateway client for AWS account %s", state.Account), err)
+		return extension_kit.ToError(fmt.Sprintf("Failed to initialize API Gateway client for AWS account %s", state.Account), err)
 	}
 	stageOut, err := client.GetStage(ctx, &apigateway.GetStageInput{
 		RestApiId: aws.String(state.ApiId),
 		StageName: aws.String(state.StageName),
 	})
 	if err != nil {
-		return nil, extension_kit.ToError(fmt.Sprintf("Failed to describe API Gateway stage %s/%s", state.ApiId, state.StageName), err)
+		return extension_kit.ToError(fmt.Sprintf("Failed to describe API Gateway stage %s/%s", state.ApiId, state.StageName), err)
 	}
 	if ms, ok := stageOut.MethodSettings["*/*"]; ok {
 		state.HadOriginalThrottleSettings = true
 		state.OriginalRateLimit = ms.ThrottlingRateLimit
 		state.OriginalBurstLimit = ms.ThrottlingBurstLimit
 	}
-	return nil, nil
+	return nil
+}
+
+func (a *stageThrottleAttack) prepareHttp(ctx context.Context, state *ApiGatewayStageThrottleAttackState) error {
+	client, err := a.httpClientProvider(state.Account, state.Region, state.DiscoveredByRole)
+	if err != nil {
+		return extension_kit.ToError(fmt.Sprintf("Failed to initialize API Gateway v2 client for AWS account %s", state.Account), err)
+	}
+	stageOut, err := client.GetStage(ctx, &apigatewayv2.GetStageInput{
+		ApiId:     aws.String(state.ApiId),
+		StageName: aws.String(state.StageName),
+	})
+	if err != nil {
+		return extension_kit.ToError(fmt.Sprintf("Failed to describe API Gateway v2 stage %s/%s", state.ApiId, state.StageName), err)
+	}
+	// HTTP $default stage on quick-created APIs is managed by API Gateway and cannot be modified — surface
+	// the constraint here instead of letting UpdateStage fail mid-experiment with a less obvious error.
+	if stageOut.ApiGatewayManaged != nil && *stageOut.ApiGatewayManaged {
+		return extension_kit.ToError(fmt.Sprintf("HTTP API stage %s/%s is managed by API Gateway and cannot be modified.", state.ApiId, state.StageName), nil)
+	}
+	if stageOut.DefaultRouteSettings != nil {
+		// Snapshot DefaultRouteSettings as JSON so we can restore non-throttle fields verbatim on Stop;
+		// v2 has no JSON-Patch shape so a Start that only sets throttling would clobber DataTraceEnabled,
+		// DetailedMetricsEnabled, LoggingLevel.
+		encoded, err := json.Marshal(stageOut.DefaultRouteSettings)
+		if err != nil {
+			return extension_kit.ToError("Failed to snapshot original DefaultRouteSettings", err)
+		}
+		state.HttpOrigDefaultRouteSettings = string(encoded)
+		if stageOut.DefaultRouteSettings.ThrottlingRateLimit != nil || stageOut.DefaultRouteSettings.ThrottlingBurstLimit != nil {
+			state.HadOriginalThrottleSettings = true
+			if stageOut.DefaultRouteSettings.ThrottlingRateLimit != nil {
+				state.OriginalRateLimit = *stageOut.DefaultRouteSettings.ThrottlingRateLimit
+			}
+			if stageOut.DefaultRouteSettings.ThrottlingBurstLimit != nil {
+				state.OriginalBurstLimit = *stageOut.DefaultRouteSettings.ThrottlingBurstLimit
+			}
+		}
+	}
+	return nil
 }
 
 func (a *stageThrottleAttack) Start(ctx context.Context, state *ApiGatewayStageThrottleAttackState) (*action_kit_api.StartResult, error) {
-	client, err := a.clientProvider(state.Account, state.Region, state.DiscoveredByRole)
+	switch state.ProtocolType {
+	case protocolREST:
+		if err := a.startRest(ctx, state); err != nil {
+			return nil, err
+		}
+	case protocolHTTP:
+		if err := a.startHttp(ctx, state); err != nil {
+			return nil, err
+		}
+	}
+	msg := fmt.Sprintf("Throttled API Gateway stage %s/%s (%s) to rate=%v, burst=%d. Original: rate=%v, burst=%d (had-settings=%t).",
+		state.ApiId, state.StageName, state.ProtocolType, state.TargetRateLimit, state.TargetBurstLimit, state.OriginalRateLimit, state.OriginalBurstLimit, state.HadOriginalThrottleSettings)
+	return &action_kit_api.StartResult{
+		Messages: extutil.Ptr([]action_kit_api.Message{{Level: extutil.Ptr(action_kit_api.Info), Message: msg}}),
+	}, nil
+}
+
+func (a *stageThrottleAttack) startRest(ctx context.Context, state *ApiGatewayStageThrottleAttackState) error {
+	client, err := a.restClientProvider(state.Account, state.Region, state.DiscoveredByRole)
 	if err != nil {
-		return nil, extension_kit.ToError(fmt.Sprintf("Failed to initialize API Gateway client for AWS account %s", state.Account), err)
+		return extension_kit.ToError(fmt.Sprintf("Failed to initialize API Gateway client for AWS account %s", state.Account), err)
 	}
 	_, err = client.UpdateStage(ctx, &apigateway.UpdateStageInput{
 		RestApiId: aws.String(state.ApiId),
@@ -144,21 +228,58 @@ func (a *stageThrottleAttack) Start(ctx context.Context, state *ApiGatewayStageT
 		},
 	})
 	if err != nil {
-		return nil, extension_kit.ToError(fmt.Sprintf("Failed to throttle API Gateway stage %s/%s", state.ApiId, state.StageName), err)
+		return extension_kit.ToError(fmt.Sprintf("Failed to throttle API Gateway stage %s/%s", state.ApiId, state.StageName), err)
 	}
-	msg := fmt.Sprintf("Throttled API Gateway stage %s/%s to rate=%v, burst=%d. Original: rate=%v, burst=%d (had-settings=%t).",
-		state.ApiId, state.StageName, state.TargetRateLimit, state.TargetBurstLimit, state.OriginalRateLimit, state.OriginalBurstLimit, state.HadOriginalThrottleSettings)
-	return &action_kit_api.StartResult{
+	return nil
+}
+
+func (a *stageThrottleAttack) startHttp(ctx context.Context, state *ApiGatewayStageThrottleAttackState) error {
+	client, err := a.httpClientProvider(state.Account, state.Region, state.DiscoveredByRole)
+	if err != nil {
+		return extension_kit.ToError(fmt.Sprintf("Failed to initialize API Gateway v2 client for AWS account %s", state.Account), err)
+	}
+	// Start from the original DefaultRouteSettings snapshot (if any) so non-throttle fields are preserved,
+	// then override the two throttle fields. v2 UpdateStage replaces the whole DefaultRouteSettings object.
+	settings := decodeRouteSettings(state.HttpOrigDefaultRouteSettings)
+	rate := state.TargetRateLimit
+	burst := state.TargetBurstLimit
+	settings.ThrottlingRateLimit = &rate
+	settings.ThrottlingBurstLimit = &burst
+	_, err = client.UpdateStage(ctx, &apigatewayv2.UpdateStageInput{
+		ApiId:                aws.String(state.ApiId),
+		StageName:            aws.String(state.StageName),
+		DefaultRouteSettings: &settings,
+	})
+	if err != nil {
+		return extension_kit.ToError(fmt.Sprintf("Failed to throttle API Gateway v2 stage %s/%s", state.ApiId, state.StageName), err)
+	}
+	return nil
+}
+
+func (a *stageThrottleAttack) Stop(ctx context.Context, state *ApiGatewayStageThrottleAttackState) (*action_kit_api.StopResult, error) {
+	switch state.ProtocolType {
+	case protocolREST:
+		if err := a.stopRest(ctx, state); err != nil {
+			log.Error().Err(err).Msgf("Failed to restore throttle settings on API Gateway stage %s/%s", state.ApiId, state.StageName)
+			return nil, err
+		}
+	case protocolHTTP:
+		if err := a.stopHttp(ctx, state); err != nil {
+			log.Error().Err(err).Msgf("Failed to restore throttle settings on API Gateway v2 stage %s/%s", state.ApiId, state.StageName)
+			return nil, err
+		}
+	}
+	msg := fmt.Sprintf("Restored throttle settings on API Gateway stage %s/%s (%s, had-settings=%t).", state.ApiId, state.StageName, state.ProtocolType, state.HadOriginalThrottleSettings)
+	return &action_kit_api.StopResult{
 		Messages: extutil.Ptr([]action_kit_api.Message{{Level: extutil.Ptr(action_kit_api.Info), Message: msg}}),
 	}, nil
 }
 
-func (a *stageThrottleAttack) Stop(ctx context.Context, state *ApiGatewayStageThrottleAttackState) (*action_kit_api.StopResult, error) {
-	client, err := a.clientProvider(state.Account, state.Region, state.DiscoveredByRole)
+func (a *stageThrottleAttack) stopRest(ctx context.Context, state *ApiGatewayStageThrottleAttackState) error {
+	client, err := a.restClientProvider(state.Account, state.Region, state.DiscoveredByRole)
 	if err != nil {
-		return nil, extension_kit.ToError(fmt.Sprintf("Failed to initialize API Gateway client for AWS account %s", state.Account), err)
+		return extension_kit.ToError(fmt.Sprintf("Failed to initialize API Gateway client for AWS account %s", state.Account), err)
 	}
-
 	patches := make([]apigwtypes.PatchOperation, 0, 2)
 	if state.HadOriginalThrottleSettings {
 		patches = append(patches,
@@ -172,18 +293,45 @@ func (a *stageThrottleAttack) Stop(ctx context.Context, state *ApiGatewayStageTh
 			apigwtypes.PatchOperation{Op: apigwtypes.OpRemove, Path: aws.String("/*/*/throttling/burstLimit")},
 		)
 	}
-
 	_, err = client.UpdateStage(ctx, &apigateway.UpdateStageInput{
 		RestApiId:       aws.String(state.ApiId),
 		StageName:       aws.String(state.StageName),
 		PatchOperations: patches,
 	})
 	if err != nil {
-		log.Error().Err(err).Msgf("Failed to restore throttle settings on API Gateway stage %s/%s", state.ApiId, state.StageName)
-		return nil, extension_kit.ToError(fmt.Sprintf("Failed to restore throttle settings on API Gateway stage %s/%s", state.ApiId, state.StageName), err)
+		return extension_kit.ToError(fmt.Sprintf("Failed to restore throttle settings on API Gateway stage %s/%s", state.ApiId, state.StageName), err)
 	}
-	msg := fmt.Sprintf("Restored throttle settings on API Gateway stage %s/%s (had-settings=%t).", state.ApiId, state.StageName, state.HadOriginalThrottleSettings)
-	return &action_kit_api.StopResult{
-		Messages: extutil.Ptr([]action_kit_api.Message{{Level: extutil.Ptr(action_kit_api.Info), Message: msg}}),
-	}, nil
+	return nil
+}
+
+func (a *stageThrottleAttack) stopHttp(ctx context.Context, state *ApiGatewayStageThrottleAttackState) error {
+	client, err := a.httpClientProvider(state.Account, state.Region, state.DiscoveredByRole)
+	if err != nil {
+		return extension_kit.ToError(fmt.Sprintf("Failed to initialize API Gateway v2 client for AWS account %s", state.Account), err)
+	}
+	// Send the original DefaultRouteSettings verbatim. If there was no original, we send an empty
+	// RouteSettings{} — that clears the throttling fields we set without affecting other stage config
+	// (v2 UpdateStage only touches fields present in the request body).
+	settings := decodeRouteSettings(state.HttpOrigDefaultRouteSettings)
+	_, err = client.UpdateStage(ctx, &apigatewayv2.UpdateStageInput{
+		ApiId:                aws.String(state.ApiId),
+		StageName:            aws.String(state.StageName),
+		DefaultRouteSettings: &settings,
+	})
+	if err != nil {
+		return extension_kit.ToError(fmt.Sprintf("Failed to restore throttle settings on API Gateway v2 stage %s/%s", state.ApiId, state.StageName), err)
+	}
+	return nil
+}
+
+func decodeRouteSettings(encoded string) apigwv2types.RouteSettings {
+	if encoded == "" {
+		return apigwv2types.RouteSettings{}
+	}
+	var rs apigwv2types.RouteSettings
+	if err := json.Unmarshal([]byte(encoded), &rs); err != nil {
+		log.Warn().Err(err).Msg("Failed to decode DefaultRouteSettings snapshot; restoring with empty settings")
+		return apigwv2types.RouteSettings{}
+	}
+	return rs
 }

--- a/extapigateway/stage_attack_throttle_test.go
+++ b/extapigateway/stage_attack_throttle_test.go
@@ -68,6 +68,7 @@ func TestPrepareThrottleCapturesOriginalSettings(t *testing.T) {
 	assert.Equal(t, "prod", state.StageName)
 	assert.Equal(t, float64(1), state.TargetRateLimit)
 	assert.Equal(t, int32(1), state.TargetBurstLimit)
+	assert.True(t, state.RestStageHadMethodSetting)
 	assert.True(t, state.HadOriginalThrottleSettings)
 	assert.Equal(t, float64(500), state.OriginalRateLimit)
 	assert.Equal(t, int32(1000), state.OriginalBurstLimit)
@@ -82,6 +83,25 @@ func TestPrepareThrottleNoOriginalSettings(t *testing.T) {
 	state := attack.NewEmptyState()
 	_, err := attack.Prepare(context.Background(), &state, newThrottleRequest(5, 10, "REST"))
 	require.NoError(t, err)
+	assert.False(t, state.RestStageHadMethodSetting)
+	assert.False(t, state.HadOriginalThrottleSettings)
+}
+
+func TestPrepareThrottleMethodSettingExistsWithoutThrottle(t *testing.T) {
+	// */* MethodSetting present but throttle fields are zero (Go SDK quirk for unset). Should NOT be
+	// treated as "had original throttle" — Stop will reset to account default instead of locking the
+	// stage to 0 rps.
+	api := new(restApiMock)
+	api.On("GetStage", mock.Anything, mock.Anything).Return(&apigateway.GetStageOutput{
+		MethodSettings: map[string]apigwtypes.MethodSetting{
+			"*/*": {CachingEnabled: true, MetricsEnabled: true},
+		},
+	}, nil)
+	attack := newRestAttack(api)
+	state := attack.NewEmptyState()
+	_, err := attack.Prepare(context.Background(), &state, newThrottleRequest(1, 1, "REST"))
+	require.NoError(t, err)
+	assert.True(t, state.RestStageHadMethodSetting)
 	assert.False(t, state.HadOriginalThrottleSettings)
 }
 
@@ -133,18 +153,46 @@ func TestStopRestoresOriginalSettings(t *testing.T) {
 	api.AssertExpectations(t)
 }
 
-func TestStopRemovesPatchesWhenNoOriginalSettings(t *testing.T) {
+func TestStopRemovesMethodSettingWhenItDidNotExist(t *testing.T) {
+	// */* MethodSetting did not exist before our Start; Stop must remove the one Start implicitly
+	// created via a single op=remove path=/*/*. Per-property op=remove is not supported by AWS.
 	api := new(restApiMock)
 	api.On("UpdateStage", mock.Anything, mock.MatchedBy(func(p *apigateway.UpdateStageInput) bool {
-		require.Equal(t, 2, len(p.PatchOperations))
+		require.Equal(t, 1, len(p.PatchOperations))
 		require.Equal(t, apigwtypes.OpRemove, p.PatchOperations[0].Op)
-		require.Equal(t, apigwtypes.OpRemove, p.PatchOperations[1].Op)
+		require.Equal(t, "/*/*", aws.ToString(p.PatchOperations[0].Path))
 		return true
 	})).Return(&apigateway.UpdateStageOutput{}, nil)
 	attack := newRestAttack(api)
 	state := ApiGatewayStageThrottleAttackState{
 		ApiId: "rest-1", StageName: "prod", ProtocolType: "REST",
 		HadOriginalThrottleSettings: false,
+		RestStageHadMethodSetting:   false,
+	}
+	_, err := attack.Stop(context.Background(), &state)
+	assert.NoError(t, err)
+	api.AssertExpectations(t)
+}
+
+func TestStopResetsToAccountDefaultWhenMethodSettingExistedWithoutThrottle(t *testing.T) {
+	// */* MethodSetting existed with caching/metrics but no throttle; Stop must reset throttle to
+	// account default (-1) without wiping the MethodSetting.
+	api := new(restApiMock)
+	api.On("UpdateStage", mock.Anything, mock.MatchedBy(func(p *apigateway.UpdateStageInput) bool {
+		require.Equal(t, 2, len(p.PatchOperations))
+		require.Equal(t, apigwtypes.OpReplace, p.PatchOperations[0].Op)
+		require.Equal(t, "/*/*/throttling/rateLimit", aws.ToString(p.PatchOperations[0].Path))
+		require.Equal(t, "-1", aws.ToString(p.PatchOperations[0].Value))
+		require.Equal(t, apigwtypes.OpReplace, p.PatchOperations[1].Op)
+		require.Equal(t, "/*/*/throttling/burstLimit", aws.ToString(p.PatchOperations[1].Path))
+		require.Equal(t, "-1", aws.ToString(p.PatchOperations[1].Value))
+		return true
+	})).Return(&apigateway.UpdateStageOutput{}, nil)
+	attack := newRestAttack(api)
+	state := ApiGatewayStageThrottleAttackState{
+		ApiId: "rest-1", StageName: "prod", ProtocolType: "REST",
+		HadOriginalThrottleSettings: false,
+		RestStageHadMethodSetting:   true,
 	}
 	_, err := attack.Stop(context.Background(), &state)
 	assert.NoError(t, err)

--- a/extapigateway/stage_attack_throttle_test.go
+++ b/extapigateway/stage_attack_throttle_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	apigwtypes "github.com/aws/aws-sdk-go-v2/service/apigateway/types"
+	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
+	apigwv2types "github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
 	"github.com/steadybit/action-kit/go/action_kit_api/v2"
 	"github.com/steadybit/extension-kit/extutil"
 	"github.com/stretchr/testify/assert"
@@ -19,19 +21,35 @@ import (
 )
 
 func newThrottleRequest(rate int, burst int, protocol string) action_kit_api.PrepareActionRequestBody {
+	apiId := "rest-1"
+	if protocol == "HTTP" {
+		apiId = "http-1"
+	}
 	return extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
 		Config: map[string]interface{}{"rateLimit": rate, "burstLimit": burst},
 		Target: extutil.Ptr(action_kit_api.Target{
 			Attributes: map[string][]string{
 				"aws.account":                      {"42"},
 				"aws.region":                       {"us-east-1"},
-				"aws.apigateway.api.id":            {"rest-1"},
+				"aws.apigateway.api.id":            {apiId},
 				"aws.apigateway.stage.name":        {"prod"},
 				"aws.apigateway.api.protocol-type": {protocol},
 				"extension-aws.discovered-by-role": {"arn:role"},
 			},
 		}),
 	})
+}
+
+func newRestAttack(api *restApiMock) stageThrottleAttack {
+	return stageThrottleAttack{
+		restClientProvider: func(account string, region string, role *string) (RestApiGatewayApi, error) { return api, nil },
+	}
+}
+
+func newHttpAttack(api *httpApiMock) stageThrottleAttack {
+	return stageThrottleAttack{
+		httpClientProvider: func(account string, region string, role *string) (HttpApiGatewayApi, error) { return api, nil },
+	}
 }
 
 func TestPrepareThrottleCapturesOriginalSettings(t *testing.T) {
@@ -41,12 +59,11 @@ func TestPrepareThrottleCapturesOriginalSettings(t *testing.T) {
 			"*/*": {ThrottlingRateLimit: 500, ThrottlingBurstLimit: 1000},
 		},
 	}, nil)
-	attack := stageThrottleAttack{clientProvider: func(account string, region string, role *string) (RestApiGatewayApi, error) {
-		return api, nil
-	}}
+	attack := newRestAttack(api)
 	state := attack.NewEmptyState()
 	_, err := attack.Prepare(context.Background(), &state, newThrottleRequest(1, 1, "REST"))
 	require.NoError(t, err)
+	assert.Equal(t, "REST", state.ProtocolType)
 	assert.Equal(t, "rest-1", state.ApiId)
 	assert.Equal(t, "prod", state.StageName)
 	assert.Equal(t, float64(1), state.TargetRateLimit)
@@ -61,20 +78,17 @@ func TestPrepareThrottleNoOriginalSettings(t *testing.T) {
 	api.On("GetStage", mock.Anything, mock.Anything).Return(&apigateway.GetStageOutput{
 		MethodSettings: map[string]apigwtypes.MethodSetting{}, // no */* override
 	}, nil)
-	attack := stageThrottleAttack{clientProvider: func(account string, region string, role *string) (RestApiGatewayApi, error) {
-		return api, nil
-	}}
+	attack := newRestAttack(api)
 	state := attack.NewEmptyState()
 	_, err := attack.Prepare(context.Background(), &state, newThrottleRequest(5, 10, "REST"))
 	require.NoError(t, err)
 	assert.False(t, state.HadOriginalThrottleSettings)
 }
 
-func TestPrepareThrottleRejectsNonRest(t *testing.T) {
-	api := new(restApiMock)
-	attack := stageThrottleAttack{clientProvider: func(account string, region string, role *string) (RestApiGatewayApi, error) { return api, nil }}
+func TestPrepareThrottleRejectsWebSocket(t *testing.T) {
+	attack := newRestAttack(new(restApiMock))
 	state := attack.NewEmptyState()
-	_, err := attack.Prepare(context.Background(), &state, newThrottleRequest(1, 1, "HTTP"))
+	_, err := attack.Prepare(context.Background(), &state, newThrottleRequest(1, 1, "WEBSOCKET"))
 	require.Error(t, err)
 }
 
@@ -91,9 +105,9 @@ func TestStartThrottlePatchesStage(t *testing.T) {
 		require.Equal(t, "1", aws.ToString(p.PatchOperations[1].Value))
 		return true
 	})).Return(&apigateway.UpdateStageOutput{}, nil)
-	attack := stageThrottleAttack{clientProvider: func(account string, region string, role *string) (RestApiGatewayApi, error) { return api, nil }}
+	attack := newRestAttack(api)
 	state := ApiGatewayStageThrottleAttackState{
-		ApiId: "rest-1", StageName: "prod", Account: "42", Region: "us-east-1",
+		ApiId: "rest-1", StageName: "prod", Account: "42", Region: "us-east-1", ProtocolType: "REST",
 		TargetRateLimit: 1, TargetBurstLimit: 1,
 	}
 	_, err := attack.Start(context.Background(), &state)
@@ -109,9 +123,9 @@ func TestStopRestoresOriginalSettings(t *testing.T) {
 		require.Equal(t, "1000", aws.ToString(p.PatchOperations[1].Value))
 		return true
 	})).Return(&apigateway.UpdateStageOutput{}, nil)
-	attack := stageThrottleAttack{clientProvider: func(account string, region string, role *string) (RestApiGatewayApi, error) { return api, nil }}
+	attack := newRestAttack(api)
 	state := ApiGatewayStageThrottleAttackState{
-		ApiId: "rest-1", StageName: "prod", Account: "42", Region: "us-east-1",
+		ApiId: "rest-1", StageName: "prod", Account: "42", Region: "us-east-1", ProtocolType: "REST",
 		HadOriginalThrottleSettings: true, OriginalRateLimit: 500, OriginalBurstLimit: 1000,
 	}
 	_, err := attack.Stop(context.Background(), &state)
@@ -127,9 +141,9 @@ func TestStopRemovesPatchesWhenNoOriginalSettings(t *testing.T) {
 		require.Equal(t, apigwtypes.OpRemove, p.PatchOperations[1].Op)
 		return true
 	})).Return(&apigateway.UpdateStageOutput{}, nil)
-	attack := stageThrottleAttack{clientProvider: func(account string, region string, role *string) (RestApiGatewayApi, error) { return api, nil }}
+	attack := newRestAttack(api)
 	state := ApiGatewayStageThrottleAttackState{
-		ApiId: "rest-1", StageName: "prod",
+		ApiId: "rest-1", StageName: "prod", ProtocolType: "REST",
 		HadOriginalThrottleSettings: false,
 	}
 	_, err := attack.Stop(context.Background(), &state)
@@ -140,8 +154,114 @@ func TestStopRemovesPatchesWhenNoOriginalSettings(t *testing.T) {
 func TestStartThrottleForwardsError(t *testing.T) {
 	api := new(restApiMock)
 	api.On("UpdateStage", mock.Anything, mock.Anything).Return(nil, errors.New("boom"))
-	attack := stageThrottleAttack{clientProvider: func(account string, region string, role *string) (RestApiGatewayApi, error) { return api, nil }}
-	state := ApiGatewayStageThrottleAttackState{ApiId: "rest-1", StageName: "prod"}
+	attack := newRestAttack(api)
+	state := ApiGatewayStageThrottleAttackState{ApiId: "rest-1", StageName: "prod", ProtocolType: "REST"}
 	_, err := attack.Start(context.Background(), &state)
 	assert.Error(t, err)
+}
+
+// --- HTTP (v2) coverage --------------------------------------------------------
+
+func TestPrepareThrottleHttpCapturesOriginalSettings(t *testing.T) {
+	api := new(httpApiMock)
+	origRate := float64(500)
+	origBurst := int32(1000)
+	dataTrace := true
+	api.On("GetStage", mock.Anything, mock.Anything).Return(&apigatewayv2.GetStageOutput{
+		StageName: aws.String("prod"),
+		DefaultRouteSettings: &apigwv2types.RouteSettings{
+			ThrottlingRateLimit:  &origRate,
+			ThrottlingBurstLimit: &origBurst,
+			DataTraceEnabled:     &dataTrace,
+		},
+	}, nil)
+	attack := newHttpAttack(api)
+	state := attack.NewEmptyState()
+	_, err := attack.Prepare(context.Background(), &state, newThrottleRequest(1, 1, "HTTP"))
+	require.NoError(t, err)
+	assert.Equal(t, "HTTP", state.ProtocolType)
+	assert.True(t, state.HadOriginalThrottleSettings)
+	assert.Equal(t, float64(500), state.OriginalRateLimit)
+	assert.Equal(t, int32(1000), state.OriginalBurstLimit)
+	assert.NotEmpty(t, state.HttpOrigDefaultRouteSettings) // JSON snapshot preserves DataTraceEnabled
+}
+
+func TestPrepareThrottleHttpRejectsManagedStage(t *testing.T) {
+	api := new(httpApiMock)
+	managed := true
+	api.On("GetStage", mock.Anything, mock.Anything).Return(&apigatewayv2.GetStageOutput{
+		StageName:         aws.String("$default"),
+		ApiGatewayManaged: &managed,
+	}, nil)
+	attack := newHttpAttack(api)
+	state := attack.NewEmptyState()
+	_, err := attack.Prepare(context.Background(), &state, newThrottleRequest(1, 1, "HTTP"))
+	require.Error(t, err)
+}
+
+func TestStartThrottleHttpPreservesOtherDefaultRouteSettings(t *testing.T) {
+	api := new(httpApiMock)
+	api.On("UpdateStage", mock.Anything, mock.MatchedBy(func(p *apigatewayv2.UpdateStageInput) bool {
+		require.Equal(t, "http-1", aws.ToString(p.ApiId))
+		require.NotNil(t, p.DefaultRouteSettings)
+		require.NotNil(t, p.DefaultRouteSettings.ThrottlingRateLimit)
+		require.Equal(t, float64(1), *p.DefaultRouteSettings.ThrottlingRateLimit)
+		require.NotNil(t, p.DefaultRouteSettings.ThrottlingBurstLimit)
+		require.Equal(t, int32(1), *p.DefaultRouteSettings.ThrottlingBurstLimit)
+		// DataTraceEnabled from the snapshot must survive Start.
+		require.NotNil(t, p.DefaultRouteSettings.DataTraceEnabled)
+		require.True(t, *p.DefaultRouteSettings.DataTraceEnabled)
+		return true
+	})).Return(&apigatewayv2.UpdateStageOutput{}, nil)
+	attack := newHttpAttack(api)
+	state := ApiGatewayStageThrottleAttackState{
+		ApiId: "http-1", StageName: "prod", ProtocolType: "HTTP",
+		TargetRateLimit: 1, TargetBurstLimit: 1,
+		HttpOrigDefaultRouteSettings: `{"DataTraceEnabled":true,"ThrottlingRateLimit":500,"ThrottlingBurstLimit":1000}`,
+	}
+	_, err := attack.Start(context.Background(), &state)
+	assert.NoError(t, err)
+	api.AssertExpectations(t)
+}
+
+func TestStopThrottleHttpRestoresSnapshot(t *testing.T) {
+	api := new(httpApiMock)
+	api.On("UpdateStage", mock.Anything, mock.MatchedBy(func(p *apigatewayv2.UpdateStageInput) bool {
+		require.NotNil(t, p.DefaultRouteSettings)
+		require.NotNil(t, p.DefaultRouteSettings.ThrottlingRateLimit)
+		require.Equal(t, float64(500), *p.DefaultRouteSettings.ThrottlingRateLimit)
+		require.NotNil(t, p.DefaultRouteSettings.ThrottlingBurstLimit)
+		require.Equal(t, int32(1000), *p.DefaultRouteSettings.ThrottlingBurstLimit)
+		return true
+	})).Return(&apigatewayv2.UpdateStageOutput{}, nil)
+	attack := newHttpAttack(api)
+	state := ApiGatewayStageThrottleAttackState{
+		ApiId: "http-1", StageName: "prod", ProtocolType: "HTTP",
+		HadOriginalThrottleSettings:  true,
+		OriginalRateLimit:            500,
+		OriginalBurstLimit:           1000,
+		HttpOrigDefaultRouteSettings: `{"ThrottlingRateLimit":500,"ThrottlingBurstLimit":1000}`,
+	}
+	_, err := attack.Stop(context.Background(), &state)
+	assert.NoError(t, err)
+	api.AssertExpectations(t)
+}
+
+func TestStopThrottleHttpClearsWhenNoOriginalSettings(t *testing.T) {
+	api := new(httpApiMock)
+	api.On("UpdateStage", mock.Anything, mock.MatchedBy(func(p *apigatewayv2.UpdateStageInput) bool {
+		require.NotNil(t, p.DefaultRouteSettings)
+		require.Nil(t, p.DefaultRouteSettings.ThrottlingRateLimit)
+		require.Nil(t, p.DefaultRouteSettings.ThrottlingBurstLimit)
+		return true
+	})).Return(&apigatewayv2.UpdateStageOutput{}, nil)
+	attack := newHttpAttack(api)
+	state := ApiGatewayStageThrottleAttackState{
+		ApiId: "http-1", StageName: "prod", ProtocolType: "HTTP",
+		HadOriginalThrottleSettings:  false,
+		HttpOrigDefaultRouteSettings: "", // stage originally had no DefaultRouteSettings
+	}
+	_, err := attack.Stop(context.Background(), &state)
+	assert.NoError(t, err)
+	api.AssertExpectations(t)
 }

--- a/extapigateway/stage_discovery_test.go
+++ b/extapigateway/stage_discovery_test.go
@@ -74,6 +74,22 @@ func (m *httpApiMock) GetStages(ctx context.Context, params *apigatewayv2.GetSta
 	return args.Get(0).(*apigatewayv2.GetStagesOutput), args.Error(1)
 }
 
+func (m *httpApiMock) GetStage(ctx context.Context, params *apigatewayv2.GetStageInput, optFns ...func(*apigatewayv2.Options)) (*apigatewayv2.GetStageOutput, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*apigatewayv2.GetStageOutput), args.Error(1)
+}
+
+func (m *httpApiMock) UpdateStage(ctx context.Context, params *apigatewayv2.UpdateStageInput, optFns ...func(*apigatewayv2.Options)) (*apigatewayv2.UpdateStageOutput, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*apigatewayv2.UpdateStageOutput), args.Error(1)
+}
+
 func TestGetAllStagesRestAndHttp(t *testing.T) {
 	rest := new(restApiMock)
 	httpApi := new(httpApiMock)


### PR DESCRIPTION
## Summary

Extends the API Gateway stage throttle attack to support HTTP APIs (v2) in addition to the REST APIs (v1) it already supports. Discovered while testing the attack on a v2 stage (`fashion-bestseller-demo/$default`) which was previously rejected at Prepare with "Throttle attack is supported on REST API stages only."

## Why v2 needed a separate code path

v1 and v2 throttle the same way conceptually (token bucket, account/stage/route layering, `429` responses — both [natively in API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-throttling.html)) but the configuration shape differs:

| | REST (v1) | HTTP (v2) |
|---|-----------|-----------|
| SDK | `apigateway` | `apigatewayv2` |
| Stage payload | `MethodSettings["*/*"]` | `DefaultRouteSettings` |
| Update semantics | JSON-Patch (`op=replace` on `/*/*/throttling/rateLimit`) | Field replacement of the whole `DefaultRouteSettings` |
| Restore "no original" | `op=remove` clears the override | Send empty `RouteSettings{}` |

The field-replacement semantics of v2 are the tricky part — sending `DefaultRouteSettings: {ThrottlingRateLimit: 1}` clears every other field that was set on the stage (DataTraceEnabled, DetailedMetricsEnabled, LoggingLevel). To avoid clobbering, this PR snapshots the entire `Stage.DefaultRouteSettings` as JSON at Prepare and restores it verbatim on Stop.

## Implementation

- `HttpApiGatewayApi` interface extended with `GetStage` + `UpdateStage`. Default provider already returns `apigatewayv2.NewFromConfig`.
- `stageThrottleAttack` now holds both `restClientProvider` and `httpClientProvider`. `Prepare`/`Start`/`Stop` switch on `aws.apigateway.api.protocol-type`.
- WEBSOCKET is rejected at Prepare with a clear message (route-throttle exists but semantics differ enough that I'd rather add it explicitly when someone needs it).
- $default stages on quick-created HTTP APIs (`ApiGatewayManaged=true`) are rejected at Prepare — AWS won't let us modify them, so failing fast is better than letting `UpdateStage` error mid-experiment.
- Snapshot strategy: marshal `Stage.DefaultRouteSettings` to JSON at Prepare and stash in `state.HttpOrigDefaultRouteSettings`. On Start, decode the JSON, override the two throttle fields, send. On Stop, decode the JSON and send back unchanged (or send `RouteSettings{}` if there was no original).
- Selection template now offers two entries: "by API id and stage (REST)" and "by API id and stage (HTTP)".
- Attack label dropped the "(REST)" suffix.

## IAM

No additions. `apigateway:GET` and `apigateway:PATCH` already cover both v1 and v2 under the shared `apigateway` IAM service. The terragrunt config we landed earlier is sufficient.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` — 308 unit tests pass (added 4 new HTTP test cases: prepare-captures-snapshot, rejects-managed-stage, start-preserves-other-route-settings, stop-restores-snapshot, stop-clears-when-no-original)
- [x] `helm lint` + `helm unittest` — 23/23 pass, snapshots unchanged
- [ ] CI on this branch
- [ ] Manual smoke test against a real HTTP API stage: short duration, soft throttle (`rate=10, burst=20`), confirm `429`s during attack and clean restore on stop

## Reversibility (unchanged classification)

Same as before for REST: truly reversible if Stop runs. HTTP path inherits the same caveat — if Stop never runs (agent crash, abandoned experiment), the stage stays at our throttle setting until manually fixed.

## Out of scope

- WebSocket API throttle support (same SDK but route-throttle semantics; add when needed)
- Per-route throttle on HTTP/v2 (currently `DefaultRouteSettings` only; matches the REST `*/*` model)