### PR TITLE
feat: add SQS visibility-timeout and DynamoDB throttle attacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ by tweaking the `Resource` clause.
 
 </details>
 <details>
-    <summary>DynamoDB-Discovery</summary>
+    <summary>DynamoDB-Discovery & Actions</summary>
 
 ```yaml
 {
@@ -204,6 +204,7 @@ by tweaking the `Resource` clause.
         "dynamodb:DescribeContinuousBackups",
         "dynamodb:DescribeTimeToLive",
         "dynamodb:ListTagsOfResource",
+        "dynamodb:UpdateTable",
         "application-autoscaling:DescribeScalableTargets"
       ],
       "Resource": "*"
@@ -211,6 +212,8 @@ by tweaking the `Resource` clause.
   ]
 }
 ```
+
+> Note: `dynamodb:UpdateTable` is only required for the "Trigger AWS DynamoDB Table Throttle" attack on PROVISIONED tables. Discovery-only deployments can omit it.
 
 </details>
 <details>
@@ -278,7 +281,7 @@ by tweaking the `Resource` clause.
 
 </details>
 <details>
-    <summary>SQS-Discovery</summary>
+    <summary>SQS-Discovery & Actions</summary>
 
 ```yaml
 {
@@ -289,13 +292,16 @@ by tweaking the `Resource` clause.
       "Action": [
         "sqs:ListQueues",
         "sqs:GetQueueAttributes",
-        "sqs:ListQueueTags"
+        "sqs:ListQueueTags",
+        "sqs:SetQueueAttributes"
       ],
       "Resource": "*"
     }
   ]
 }
 ```
+
+> Note: `sqs:SetQueueAttributes` is only required for the "Trigger AWS SQS Queue Visibility Timeout Change" attack. Discovery-only deployments can omit it.
 
 </details>
 <details>

--- a/charts/steadybit-extension-aws/Chart.yaml
+++ b/charts/steadybit-extension-aws/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-extension-aws
 description: Steadybit AWS extension Helm chart for Kubernetes.
-version: 2.2.25
+version: 2.2.26
 appVersion: v2.4.14
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/extdynamodb/common.go
+++ b/extdynamodb/common.go
@@ -22,6 +22,24 @@ type DynamodbApi interface {
 	DescribeContinuousBackups(ctx context.Context, params *dynamodb.DescribeContinuousBackupsInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DescribeContinuousBackupsOutput, error)
 	DescribeTimeToLive(ctx context.Context, params *dynamodb.DescribeTimeToLiveInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DescribeTimeToLiveOutput, error)
 	ListTagsOfResource(ctx context.Context, params *dynamodb.ListTagsOfResourceInput, optFns ...func(*dynamodb.Options)) (*dynamodb.ListTagsOfResourceOutput, error)
+	UpdateTable(ctx context.Context, params *dynamodb.UpdateTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateTableOutput, error)
+}
+
+// TableThrottleAttackState captures the original provisioned capacity for a PROVISIONED-mode table
+// (and each of its GSIs) so we can restore on Stop.
+type TableThrottleAttackState struct {
+	TableName        string
+	Account          string
+	Region           string
+	DiscoveredByRole *string
+
+	OriginalReadCapacity  int64
+	OriginalWriteCapacity int64
+	// GSI name → [read, write]
+	OriginalGsiCapacity map[string][2]int64
+
+	TargetReadCapacity  int64
+	TargetWriteCapacity int64
 }
 
 type AppAutoScalingApi interface {

--- a/extdynamodb/table_attack_throttle.go
+++ b/extdynamodb/table_attack_throttle.go
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+
+package extdynamodb
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/rs/zerolog/log"
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/action-kit/go/action_kit_sdk"
+	"github.com/steadybit/extension-aws/v2/utils"
+	extension_kit "github.com/steadybit/extension-kit"
+	"github.com/steadybit/extension-kit/extbuild"
+	"github.com/steadybit/extension-kit/extutil"
+)
+
+type tableThrottleAttack struct {
+	clientProvider func(account string, region string, role *string) (DynamodbApi, error)
+}
+
+var (
+	_ action_kit_sdk.Action[TableThrottleAttackState]         = (*tableThrottleAttack)(nil)
+	_ action_kit_sdk.ActionWithStop[TableThrottleAttackState] = (*tableThrottleAttack)(nil)
+)
+
+func NewTableThrottleAttack() action_kit_sdk.ActionWithStop[TableThrottleAttackState] {
+	return &tableThrottleAttack{
+		clientProvider: func(account string, region string, role *string) (DynamodbApi, error) {
+			awsAccess, err := utils.GetAwsAccess(account, region, role)
+			if err != nil {
+				return nil, err
+			}
+			return dynamodb.NewFromConfig(awsAccess.AwsConfig), nil
+		},
+	}
+}
+
+func (a *tableThrottleAttack) NewEmptyState() TableThrottleAttackState {
+	return TableThrottleAttackState{}
+}
+
+func (a *tableThrottleAttack) Describe() action_kit_api.ActionDescription {
+	return action_kit_api.ActionDescription{
+		Id:    fmt.Sprintf("%s.throttle", tableTargetId),
+		Label: "Trigger AWS DynamoDB Table Throttle",
+		Description: "Temporarily lowers a PROVISIONED-mode DynamoDB table's read + write capacity (and the capacity of each GSI) to force ProvisionedThroughputExceededException. " +
+			"Validates client retry / backoff logic and circuit breakers. Original capacities are restored on stop. " +
+			"Tables in PAY_PER_REQUEST mode are not supported (no fixed capacity to lower). If the table has Application Auto Scaling, the autoscaler will eventually scale back up; " +
+			"the attack still exercises the throttle path during the autoscaler's reaction window.",
+		Version: extbuild.GetSemverVersionStringOrUnknown(),
+		Icon:    new(dynamodbIcon),
+		TargetSelection: new(action_kit_api.TargetSelection{
+			TargetType: tableTargetId,
+			SelectionTemplates: new([]action_kit_api.TargetSelectionTemplate{
+				{
+					Label:       "by table name",
+					Description: new("Find DynamoDB table by name"),
+					Query:       "aws.dynamodb.table.name=\"\"",
+				},
+			}),
+		}),
+		Technology:  new("AWS"),
+		Category:    new("DynamoDB"),
+		TimeControl: action_kit_api.TimeControlExternal,
+		Kind:        action_kit_api.Attack,
+		Parameters: []action_kit_api.ActionParameter{
+			{
+				Name:         "duration",
+				Label:        "Duration",
+				Description:  new("How long the lowered capacity stays in effect. Originals restored on stop."),
+				Type:         action_kit_api.ActionParameterTypeDuration,
+				DefaultValue: new("60s"),
+				Order:        new(1),
+				Required:     new(true),
+			},
+			{
+				Name:         "readCapacity",
+				Label:        "Target read capacity (RCU)",
+				Description:  new("New ReadCapacityUnits for the table and each GSI. Use 1 for aggressive throttling."),
+				Type:         action_kit_api.ActionParameterTypeInteger,
+				DefaultValue: new("1"),
+				Order:        new(2),
+				Required:     new(true),
+				MinValue:     new(1),
+			},
+			{
+				Name:         "writeCapacity",
+				Label:        "Target write capacity (WCU)",
+				Description:  new("New WriteCapacityUnits for the table and each GSI. Use 1 for aggressive throttling."),
+				Type:         action_kit_api.ActionParameterTypeInteger,
+				DefaultValue: new("1"),
+				Order:        new(3),
+				Required:     new(true),
+				MinValue:     new(1),
+			},
+		},
+		Stop: new(action_kit_api.MutatingEndpointReference{}),
+	}
+}
+
+func (a *tableThrottleAttack) Prepare(ctx context.Context, state *TableThrottleAttackState, request action_kit_api.PrepareActionRequestBody) (*action_kit_api.PrepareResult, error) {
+	state.Account = extutil.MustHaveValue(request.Target.Attributes, "aws.account")[0]
+	state.Region = extutil.MustHaveValue(request.Target.Attributes, "aws.region")[0]
+	state.TableName = extutil.MustHaveValue(request.Target.Attributes, "aws.dynamodb.table.name")[0]
+	state.DiscoveredByRole = utils.GetOptionalTargetAttribute(request.Target.Attributes, "extension-aws.discovered-by-role")
+
+	read := int64(extutil.ToInt(request.Config["readCapacity"]))
+	write := int64(extutil.ToInt(request.Config["writeCapacity"]))
+	if read < 1 || write < 1 {
+		return nil, extension_kit.ToError("readCapacity and writeCapacity must be >= 1.", nil)
+	}
+	state.TargetReadCapacity = read
+	state.TargetWriteCapacity = write
+
+	client, err := a.clientProvider(state.Account, state.Region, state.DiscoveredByRole)
+	if err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to initialize DynamoDB client for AWS account %s", state.Account), err)
+	}
+	out, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String(state.TableName)})
+	if err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to describe DynamoDB table %s", state.TableName), err)
+	}
+	if out.Table == nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("DynamoDB table %s not found", state.TableName), nil)
+	}
+
+	// PAY_PER_REQUEST tables have no fixed capacity; reject.
+	if out.Table.BillingModeSummary != nil && out.Table.BillingModeSummary.BillingMode == ddbtypes.BillingModePayPerRequest {
+		return nil, extension_kit.ToError(fmt.Sprintf("DynamoDB table %s is in PAY_PER_REQUEST mode; throttle attack only supports PROVISIONED tables.", state.TableName), nil)
+	}
+
+	if pt := out.Table.ProvisionedThroughput; pt != nil {
+		state.OriginalReadCapacity = aws.ToInt64(pt.ReadCapacityUnits)
+		state.OriginalWriteCapacity = aws.ToInt64(pt.WriteCapacityUnits)
+	}
+	state.OriginalGsiCapacity = make(map[string][2]int64)
+	for _, gsi := range out.Table.GlobalSecondaryIndexes {
+		if gsi.IndexName == nil || gsi.ProvisionedThroughput == nil {
+			continue
+		}
+		state.OriginalGsiCapacity[*gsi.IndexName] = [2]int64{
+			aws.ToInt64(gsi.ProvisionedThroughput.ReadCapacityUnits),
+			aws.ToInt64(gsi.ProvisionedThroughput.WriteCapacityUnits),
+		}
+	}
+	return &action_kit_api.PrepareResult{
+		Messages: extutil.Ptr([]action_kit_api.Message{{
+			Level:   extutil.Ptr(action_kit_api.Info),
+			Message: fmt.Sprintf("Will throttle table %s to RCU=%d WCU=%d (was RCU=%d WCU=%d) and %d GSI(s) to the same values.", state.TableName, state.TargetReadCapacity, state.TargetWriteCapacity, state.OriginalReadCapacity, state.OriginalWriteCapacity, len(state.OriginalGsiCapacity)),
+		}}),
+	}, nil
+}
+
+func (a *tableThrottleAttack) Start(ctx context.Context, state *TableThrottleAttackState) (*action_kit_api.StartResult, error) {
+	if err := a.updateCapacity(ctx, state, state.TargetReadCapacity, state.TargetWriteCapacity, gsiTarget(state, state.TargetReadCapacity, state.TargetWriteCapacity)); err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to throttle DynamoDB table %s", state.TableName), err)
+	}
+	return &action_kit_api.StartResult{
+		Messages: extutil.Ptr([]action_kit_api.Message{{
+			Level:   extutil.Ptr(action_kit_api.Info),
+			Message: fmt.Sprintf("Throttled table %s to RCU=%d WCU=%d", state.TableName, state.TargetReadCapacity, state.TargetWriteCapacity),
+		}}),
+	}, nil
+}
+
+func (a *tableThrottleAttack) Stop(ctx context.Context, state *TableThrottleAttackState) (*action_kit_api.StopResult, error) {
+	if err := a.updateCapacity(ctx, state, state.OriginalReadCapacity, state.OriginalWriteCapacity, state.OriginalGsiCapacity); err != nil {
+		log.Error().Err(err).Msgf("Failed to restore DynamoDB table %s capacity", state.TableName)
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to restore capacity on DynamoDB table %s", state.TableName), err)
+	}
+	return &action_kit_api.StopResult{
+		Messages: extutil.Ptr([]action_kit_api.Message{{
+			Level:   extutil.Ptr(action_kit_api.Info),
+			Message: fmt.Sprintf("Restored table %s capacity to RCU=%d WCU=%d", state.TableName, state.OriginalReadCapacity, state.OriginalWriteCapacity),
+		}}),
+	}, nil
+}
+
+// gsiTarget builds a per-GSI capacity map setting every GSI to the same (read,write) tuple.
+func gsiTarget(state *TableThrottleAttackState, read, write int64) map[string][2]int64 {
+	out := make(map[string][2]int64, len(state.OriginalGsiCapacity))
+	for name := range state.OriginalGsiCapacity {
+		out[name] = [2]int64{read, write}
+	}
+	return out
+}
+
+func (a *tableThrottleAttack) updateCapacity(ctx context.Context, state *TableThrottleAttackState, read, write int64, gsiCapacity map[string][2]int64) error {
+	client, err := a.clientProvider(state.Account, state.Region, state.DiscoveredByRole)
+	if err != nil {
+		return err
+	}
+	input := &dynamodb.UpdateTableInput{
+		TableName: aws.String(state.TableName),
+		ProvisionedThroughput: &ddbtypes.ProvisionedThroughput{
+			ReadCapacityUnits:  aws.Int64(read),
+			WriteCapacityUnits: aws.Int64(write),
+		},
+	}
+	if len(gsiCapacity) > 0 {
+		updates := make([]ddbtypes.GlobalSecondaryIndexUpdate, 0, len(gsiCapacity))
+		for name, rw := range gsiCapacity {
+			n := name
+			updates = append(updates, ddbtypes.GlobalSecondaryIndexUpdate{
+				Update: &ddbtypes.UpdateGlobalSecondaryIndexAction{
+					IndexName: &n,
+					ProvisionedThroughput: &ddbtypes.ProvisionedThroughput{
+						ReadCapacityUnits:  aws.Int64(rw[0]),
+						WriteCapacityUnits: aws.Int64(rw[1]),
+					},
+				},
+			})
+		}
+		input.GlobalSecondaryIndexUpdates = updates
+	}
+	_, err = client.UpdateTable(ctx, input)
+	return err
+}

--- a/extdynamodb/table_attack_throttle_test.go
+++ b/extdynamodb/table_attack_throttle_test.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+
+package extdynamodb
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/extension-kit/extutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func newThrottleRequest(read, write int) action_kit_api.PrepareActionRequestBody {
+	return extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
+		Config: map[string]interface{}{"readCapacity": read, "writeCapacity": write},
+		Target: extutil.Ptr(action_kit_api.Target{
+			Attributes: map[string][]string{
+				"aws.account":                      {"42"},
+				"aws.region":                       {"us-east-1"},
+				"aws.dynamodb.table.name":          {"my-table"},
+				"extension-aws.discovered-by-role": {"arn:role"},
+			},
+		}),
+	})
+}
+
+func newThrottleAttack(api *ddbApiMock) tableThrottleAttack {
+	return tableThrottleAttack{
+		clientProvider: func(account string, region string, role *string) (DynamodbApi, error) { return api, nil },
+	}
+}
+
+func TestThrottlePrepareCapturesTableAndGsiCapacity(t *testing.T) {
+	api := new(ddbApiMock)
+	api.On("DescribeTable", mock.Anything, mock.Anything).Return(&dynamodb.DescribeTableOutput{
+		Table: &ddbtypes.TableDescription{
+			TableName:          aws.String("my-table"),
+			BillingModeSummary: &ddbtypes.BillingModeSummary{BillingMode: ddbtypes.BillingModeProvisioned},
+			ProvisionedThroughput: &ddbtypes.ProvisionedThroughputDescription{
+				ReadCapacityUnits:  aws.Int64(100),
+				WriteCapacityUnits: aws.Int64(50),
+			},
+			GlobalSecondaryIndexes: []ddbtypes.GlobalSecondaryIndexDescription{
+				{
+					IndexName: aws.String("gsi-1"),
+					ProvisionedThroughput: &ddbtypes.ProvisionedThroughputDescription{
+						ReadCapacityUnits:  aws.Int64(20),
+						WriteCapacityUnits: aws.Int64(10),
+					},
+				},
+			},
+		},
+	}, nil)
+	a := newThrottleAttack(api)
+	state := a.NewEmptyState()
+	_, err := a.Prepare(context.Background(), &state, newThrottleRequest(1, 1))
+	require.NoError(t, err)
+	assert.Equal(t, int64(100), state.OriginalReadCapacity)
+	assert.Equal(t, int64(50), state.OriginalWriteCapacity)
+	assert.Equal(t, [2]int64{20, 10}, state.OriginalGsiCapacity["gsi-1"])
+	assert.Equal(t, int64(1), state.TargetReadCapacity)
+	assert.Equal(t, int64(1), state.TargetWriteCapacity)
+}
+
+func TestThrottlePrepareRejectsPayPerRequest(t *testing.T) {
+	api := new(ddbApiMock)
+	api.On("DescribeTable", mock.Anything, mock.Anything).Return(&dynamodb.DescribeTableOutput{
+		Table: &ddbtypes.TableDescription{
+			TableName:          aws.String("my-table"),
+			BillingModeSummary: &ddbtypes.BillingModeSummary{BillingMode: ddbtypes.BillingModePayPerRequest},
+		},
+	}, nil)
+	a := newThrottleAttack(api)
+	state := a.NewEmptyState()
+	_, err := a.Prepare(context.Background(), &state, newThrottleRequest(1, 1))
+	require.Error(t, err)
+}
+
+func TestThrottleStartUpdatesTableAndGsis(t *testing.T) {
+	api := new(ddbApiMock)
+	api.On("UpdateTable", mock.Anything, mock.MatchedBy(func(p *dynamodb.UpdateTableInput) bool {
+		require.Equal(t, "my-table", aws.ToString(p.TableName))
+		require.NotNil(t, p.ProvisionedThroughput)
+		require.Equal(t, int64(1), aws.ToInt64(p.ProvisionedThroughput.ReadCapacityUnits))
+		require.Equal(t, int64(2), aws.ToInt64(p.ProvisionedThroughput.WriteCapacityUnits))
+		require.Len(t, p.GlobalSecondaryIndexUpdates, 1)
+		require.Equal(t, "gsi-1", aws.ToString(p.GlobalSecondaryIndexUpdates[0].Update.IndexName))
+		require.Equal(t, int64(1), aws.ToInt64(p.GlobalSecondaryIndexUpdates[0].Update.ProvisionedThroughput.ReadCapacityUnits))
+		require.Equal(t, int64(2), aws.ToInt64(p.GlobalSecondaryIndexUpdates[0].Update.ProvisionedThroughput.WriteCapacityUnits))
+		return true
+	})).Return(&dynamodb.UpdateTableOutput{}, nil)
+	a := newThrottleAttack(api)
+	state := TableThrottleAttackState{
+		TableName: "my-table", Account: "42", Region: "us-east-1",
+		OriginalReadCapacity: 100, OriginalWriteCapacity: 50,
+		OriginalGsiCapacity: map[string][2]int64{"gsi-1": {20, 10}},
+		TargetReadCapacity:  1, TargetWriteCapacity: 2,
+	}
+	_, err := a.Start(context.Background(), &state)
+	require.NoError(t, err)
+	api.AssertExpectations(t)
+}
+
+func TestThrottleStopRestoresOriginalCapacity(t *testing.T) {
+	api := new(ddbApiMock)
+	api.On("UpdateTable", mock.Anything, mock.MatchedBy(func(p *dynamodb.UpdateTableInput) bool {
+		require.Equal(t, int64(100), aws.ToInt64(p.ProvisionedThroughput.ReadCapacityUnits))
+		require.Equal(t, int64(50), aws.ToInt64(p.ProvisionedThroughput.WriteCapacityUnits))
+		require.Len(t, p.GlobalSecondaryIndexUpdates, 1)
+		require.Equal(t, int64(20), aws.ToInt64(p.GlobalSecondaryIndexUpdates[0].Update.ProvisionedThroughput.ReadCapacityUnits))
+		require.Equal(t, int64(10), aws.ToInt64(p.GlobalSecondaryIndexUpdates[0].Update.ProvisionedThroughput.WriteCapacityUnits))
+		return true
+	})).Return(&dynamodb.UpdateTableOutput{}, nil)
+	a := newThrottleAttack(api)
+	state := TableThrottleAttackState{
+		TableName:            "my-table",
+		OriginalReadCapacity: 100, OriginalWriteCapacity: 50,
+		OriginalGsiCapacity: map[string][2]int64{"gsi-1": {20, 10}},
+		TargetReadCapacity:  1, TargetWriteCapacity: 1,
+	}
+	_, err := a.Stop(context.Background(), &state)
+	require.NoError(t, err)
+	api.AssertExpectations(t)
+}
+
+func TestThrottleStartForwardsError(t *testing.T) {
+	api := new(ddbApiMock)
+	api.On("UpdateTable", mock.Anything, mock.Anything).Return(nil, errors.New("boom"))
+	a := newThrottleAttack(api)
+	state := TableThrottleAttackState{TableName: "t", TargetReadCapacity: 1, TargetWriteCapacity: 1}
+	_, err := a.Start(context.Background(), &state)
+	assert.Error(t, err)
+}

--- a/extdynamodb/table_discovery_test.go
+++ b/extdynamodb/table_discovery_test.go
@@ -63,6 +63,14 @@ func (m *ddbApiMock) ListTagsOfResource(ctx context.Context, params *dynamodb.Li
 	return args.Get(0).(*dynamodb.ListTagsOfResourceOutput), args.Error(1)
 }
 
+func (m *ddbApiMock) UpdateTable(ctx context.Context, params *dynamodb.UpdateTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateTableOutput, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dynamodb.UpdateTableOutput), args.Error(1)
+}
+
 type aasApiMock struct {
 	mock.Mock
 }

--- a/extsqs/common.go
+++ b/extsqs/common.go
@@ -18,4 +18,16 @@ type SqsApi interface {
 	sqs.ListQueuesAPIClient
 	GetQueueAttributes(ctx context.Context, params *sqs.GetQueueAttributesInput, optFns ...func(*sqs.Options)) (*sqs.GetQueueAttributesOutput, error)
 	ListQueueTags(ctx context.Context, params *sqs.ListQueueTagsInput, optFns ...func(*sqs.Options)) (*sqs.ListQueueTagsOutput, error)
+	SetQueueAttributes(ctx context.Context, params *sqs.SetQueueAttributesInput, optFns ...func(*sqs.Options)) (*sqs.SetQueueAttributesOutput, error)
+}
+
+// QueueVisibilityTimeoutAttackState captures the original VisibilityTimeout so we can restore on Stop.
+type QueueVisibilityTimeoutAttackState struct {
+	QueueUrl                  string
+	QueueName                 string
+	Account                   string
+	Region                    string
+	DiscoveredByRole          *string
+	OriginalVisibilityTimeout int32
+	TargetVisibilityTimeout   int32
 }

--- a/extsqs/queue_attack_visibility_timeout.go
+++ b/extsqs/queue_attack_visibility_timeout.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+
+package extsqs
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/rs/zerolog/log"
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/action-kit/go/action_kit_sdk"
+	"github.com/steadybit/extension-aws/v2/utils"
+	extension_kit "github.com/steadybit/extension-kit"
+	"github.com/steadybit/extension-kit/extbuild"
+	"github.com/steadybit/extension-kit/extutil"
+)
+
+type queueVisibilityTimeoutAttack struct {
+	clientProvider func(account string, region string, role *string) (SqsApi, error)
+}
+
+var (
+	_ action_kit_sdk.Action[QueueVisibilityTimeoutAttackState]         = (*queueVisibilityTimeoutAttack)(nil)
+	_ action_kit_sdk.ActionWithStop[QueueVisibilityTimeoutAttackState] = (*queueVisibilityTimeoutAttack)(nil)
+)
+
+func NewQueueVisibilityTimeoutAttack() action_kit_sdk.ActionWithStop[QueueVisibilityTimeoutAttackState] {
+	return &queueVisibilityTimeoutAttack{clientProvider: defaultSqsClientProvider}
+}
+
+func (a *queueVisibilityTimeoutAttack) NewEmptyState() QueueVisibilityTimeoutAttackState {
+	return QueueVisibilityTimeoutAttackState{}
+}
+
+func (a *queueVisibilityTimeoutAttack) Describe() action_kit_api.ActionDescription {
+	return action_kit_api.ActionDescription{
+		Id:    fmt.Sprintf("%s.visibility-timeout", queueTargetType),
+		Label: "Trigger AWS SQS Queue Visibility Timeout Change",
+		Description: "Temporarily changes the SQS queue's visibility timeout. Set it very low (0-5s) to force premature redelivery and stress consumer idempotency, " +
+			"or very high (close to the 12-hour max) to stall redelivery and reveal stuck-message handling. Original timeout is restored on stop.",
+		Version: extbuild.GetSemverVersionStringOrUnknown(),
+		Icon:    new(sqsIcon),
+		TargetSelection: new(action_kit_api.TargetSelection{
+			TargetType: queueTargetType,
+			SelectionTemplates: new([]action_kit_api.TargetSelectionTemplate{
+				{
+					Label:       "by queue name",
+					Description: new("Find SQS queue by name"),
+					Query:       "aws.sqs.queue.name=\"\"",
+				},
+			}),
+		}),
+		Technology:  new("AWS"),
+		Category:    new("SQS"),
+		TimeControl: action_kit_api.TimeControlExternal,
+		Kind:        action_kit_api.Attack,
+		Parameters: []action_kit_api.ActionParameter{
+			{
+				Name:         "duration",
+				Label:        "Duration",
+				Description:  new("How long the modified visibility timeout stays in effect. Original value is restored on stop."),
+				Type:         action_kit_api.ActionParameterTypeDuration,
+				DefaultValue: new("60s"),
+				Order:        new(1),
+				Required:     new(true),
+			},
+			{
+				Name:         "visibilityTimeoutSeconds",
+				Label:        "New visibility timeout (seconds)",
+				Description:  new("New visibility timeout in seconds. Valid range: 0-43200 (12 hours). Use 0-5 to force premature redelivery; use a high value to stall redelivery."),
+				Type:         action_kit_api.ActionParameterTypeInteger,
+				DefaultValue: new("0"),
+				Order:        new(2),
+				Required:     new(true),
+				MinValue:     new(0),
+				MaxValue:     new(43200),
+			},
+		},
+		Stop: new(action_kit_api.MutatingEndpointReference{}),
+	}
+}
+
+func (a *queueVisibilityTimeoutAttack) Prepare(ctx context.Context, state *QueueVisibilityTimeoutAttackState, request action_kit_api.PrepareActionRequestBody) (*action_kit_api.PrepareResult, error) {
+	state.Account = extutil.MustHaveValue(request.Target.Attributes, "aws.account")[0]
+	state.Region = extutil.MustHaveValue(request.Target.Attributes, "aws.region")[0]
+	state.QueueUrl = extutil.MustHaveValue(request.Target.Attributes, "aws.sqs.queue.url")[0]
+	state.QueueName = extutil.MustHaveValue(request.Target.Attributes, "aws.sqs.queue.name")[0]
+	state.DiscoveredByRole = utils.GetOptionalTargetAttribute(request.Target.Attributes, "extension-aws.discovered-by-role")
+
+	target := extutil.ToInt(request.Config["visibilityTimeoutSeconds"])
+	if target < 0 || target > 43200 {
+		return nil, extension_kit.ToError("visibilityTimeoutSeconds must be between 0 and 43200 (12 hours).", nil)
+	}
+	state.TargetVisibilityTimeout = int32(target)
+
+	client, err := a.clientProvider(state.Account, state.Region, state.DiscoveredByRole)
+	if err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to initialize SQS client for AWS account %s", state.Account), err)
+	}
+	out, err := client.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
+		QueueUrl:       &state.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameVisibilityTimeout},
+	})
+	if err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to describe SQS queue %s", state.QueueName), err)
+	}
+	if v, ok := out.Attributes[string(sqstypes.QueueAttributeNameVisibilityTimeout)]; ok {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, extension_kit.ToError(fmt.Sprintf("Failed to parse original VisibilityTimeout %q for queue %s", v, state.QueueName), err)
+		}
+		state.OriginalVisibilityTimeout = int32(n)
+	} else {
+		// SQS default when unset is 30s.
+		state.OriginalVisibilityTimeout = 30
+	}
+	return &action_kit_api.PrepareResult{
+		Messages: extutil.Ptr([]action_kit_api.Message{{
+			Level:   extutil.Ptr(action_kit_api.Info),
+			Message: fmt.Sprintf("Will change VisibilityTimeout on queue %s from %d to %d for the attack duration", state.QueueName, state.OriginalVisibilityTimeout, state.TargetVisibilityTimeout),
+		}}),
+	}, nil
+}
+
+func (a *queueVisibilityTimeoutAttack) Start(ctx context.Context, state *QueueVisibilityTimeoutAttackState) (*action_kit_api.StartResult, error) {
+	if err := a.setVisibilityTimeout(ctx, state, state.TargetVisibilityTimeout); err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to change VisibilityTimeout on SQS queue %s", state.QueueName), err)
+	}
+	return &action_kit_api.StartResult{
+		Messages: extutil.Ptr([]action_kit_api.Message{{
+			Level:   extutil.Ptr(action_kit_api.Info),
+			Message: fmt.Sprintf("Set VisibilityTimeout on queue %s to %d (was %d)", state.QueueName, state.TargetVisibilityTimeout, state.OriginalVisibilityTimeout),
+		}}),
+	}, nil
+}
+
+func (a *queueVisibilityTimeoutAttack) Stop(ctx context.Context, state *QueueVisibilityTimeoutAttackState) (*action_kit_api.StopResult, error) {
+	if err := a.setVisibilityTimeout(ctx, state, state.OriginalVisibilityTimeout); err != nil {
+		log.Error().Err(err).Msgf("Failed to restore VisibilityTimeout on SQS queue %s", state.QueueName)
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to restore VisibilityTimeout on SQS queue %s", state.QueueName), err)
+	}
+	return &action_kit_api.StopResult{
+		Messages: extutil.Ptr([]action_kit_api.Message{{
+			Level:   extutil.Ptr(action_kit_api.Info),
+			Message: fmt.Sprintf("Restored VisibilityTimeout on queue %s to %d", state.QueueName, state.OriginalVisibilityTimeout),
+		}}),
+	}, nil
+}
+
+func (a *queueVisibilityTimeoutAttack) setVisibilityTimeout(ctx context.Context, state *QueueVisibilityTimeoutAttackState, value int32) error {
+	client, err := a.clientProvider(state.Account, state.Region, state.DiscoveredByRole)
+	if err != nil {
+		return err
+	}
+	_, err = client.SetQueueAttributes(ctx, &sqs.SetQueueAttributesInput{
+		QueueUrl: &state.QueueUrl,
+		Attributes: map[string]string{
+			string(sqstypes.QueueAttributeNameVisibilityTimeout): strconv.Itoa(int(value)),
+		},
+	})
+	return err
+}
+
+func defaultSqsClientProvider(account string, region string, role *string) (SqsApi, error) {
+	awsAccess, err := utils.GetAwsAccess(account, region, role)
+	if err != nil {
+		return nil, err
+	}
+	return sqs.NewFromConfig(awsAccess.AwsConfig), nil
+}

--- a/extsqs/queue_attack_visibility_timeout_test.go
+++ b/extsqs/queue_attack_visibility_timeout_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+
+package extsqs
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/extension-kit/extutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type sqsApiMock struct {
+	mock.Mock
+}
+
+func (m *sqsApiMock) ListQueues(ctx context.Context, params *sqs.ListQueuesInput, optFns ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*sqs.ListQueuesOutput), args.Error(1)
+}
+
+func (m *sqsApiMock) GetQueueAttributes(ctx context.Context, params *sqs.GetQueueAttributesInput, optFns ...func(*sqs.Options)) (*sqs.GetQueueAttributesOutput, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*sqs.GetQueueAttributesOutput), args.Error(1)
+}
+
+func (m *sqsApiMock) ListQueueTags(ctx context.Context, params *sqs.ListQueueTagsInput, optFns ...func(*sqs.Options)) (*sqs.ListQueueTagsOutput, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*sqs.ListQueueTagsOutput), args.Error(1)
+}
+
+func (m *sqsApiMock) SetQueueAttributes(ctx context.Context, params *sqs.SetQueueAttributesInput, optFns ...func(*sqs.Options)) (*sqs.SetQueueAttributesOutput, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*sqs.SetQueueAttributesOutput), args.Error(1)
+}
+
+func newVisibilityRequest(target int) action_kit_api.PrepareActionRequestBody {
+	return extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
+		Config: map[string]interface{}{"visibilityTimeoutSeconds": target},
+		Target: extutil.Ptr(action_kit_api.Target{
+			Attributes: map[string][]string{
+				"aws.account":                      {"42"},
+				"aws.region":                       {"us-east-1"},
+				"aws.sqs.queue.url":                {"https://sqs.us-east-1.amazonaws.com/42/test-queue"},
+				"aws.sqs.queue.name":               {"test-queue"},
+				"extension-aws.discovered-by-role": {"arn:role"},
+			},
+		}),
+	})
+}
+
+func newAttack(api *sqsApiMock) queueVisibilityTimeoutAttack {
+	return queueVisibilityTimeoutAttack{
+		clientProvider: func(account string, region string, role *string) (SqsApi, error) { return api, nil },
+	}
+}
+
+func TestPrepareCapturesOriginalVisibilityTimeout(t *testing.T) {
+	api := new(sqsApiMock)
+	api.On("GetQueueAttributes", mock.Anything, mock.Anything).Return(&sqs.GetQueueAttributesOutput{
+		Attributes: map[string]string{string(sqstypes.QueueAttributeNameVisibilityTimeout): "60"},
+	}, nil)
+	a := newAttack(api)
+	state := a.NewEmptyState()
+	_, err := a.Prepare(context.Background(), &state, newVisibilityRequest(0))
+	require.NoError(t, err)
+	assert.Equal(t, int32(60), state.OriginalVisibilityTimeout)
+	assert.Equal(t, int32(0), state.TargetVisibilityTimeout)
+}
+
+func TestPrepareFallsBackToSqsDefaultWhenAttributeMissing(t *testing.T) {
+	api := new(sqsApiMock)
+	api.On("GetQueueAttributes", mock.Anything, mock.Anything).Return(&sqs.GetQueueAttributesOutput{
+		Attributes: map[string]string{},
+	}, nil)
+	a := newAttack(api)
+	state := a.NewEmptyState()
+	_, err := a.Prepare(context.Background(), &state, newVisibilityRequest(10))
+	require.NoError(t, err)
+	assert.Equal(t, int32(30), state.OriginalVisibilityTimeout, "SQS default when unset is 30s")
+}
+
+func TestStartAppliesTargetTimeout(t *testing.T) {
+	api := new(sqsApiMock)
+	api.On("SetQueueAttributes", mock.Anything, mock.MatchedBy(func(p *sqs.SetQueueAttributesInput) bool {
+		v, ok := p.Attributes[string(sqstypes.QueueAttributeNameVisibilityTimeout)]
+		require.True(t, ok)
+		n, _ := strconv.Atoi(v)
+		require.Equal(t, 5, n)
+		return true
+	})).Return(&sqs.SetQueueAttributesOutput{}, nil)
+	a := newAttack(api)
+	state := QueueVisibilityTimeoutAttackState{
+		QueueUrl: "url", QueueName: "test-queue", Account: "42", Region: "us-east-1",
+		OriginalVisibilityTimeout: 60, TargetVisibilityTimeout: 5,
+	}
+	_, err := a.Start(context.Background(), &state)
+	require.NoError(t, err)
+	api.AssertExpectations(t)
+}
+
+func TestStopRestoresOriginalTimeout(t *testing.T) {
+	api := new(sqsApiMock)
+	api.On("SetQueueAttributes", mock.Anything, mock.MatchedBy(func(p *sqs.SetQueueAttributesInput) bool {
+		v := p.Attributes[string(sqstypes.QueueAttributeNameVisibilityTimeout)]
+		require.Equal(t, "60", v)
+		return true
+	})).Return(&sqs.SetQueueAttributesOutput{}, nil)
+	a := newAttack(api)
+	state := QueueVisibilityTimeoutAttackState{
+		QueueUrl: "url", QueueName: "test-queue",
+		OriginalVisibilityTimeout: 60, TargetVisibilityTimeout: 5,
+	}
+	_, err := a.Stop(context.Background(), &state)
+	require.NoError(t, err)
+	api.AssertExpectations(t)
+}
+
+func TestPrepareRejectsOutOfRange(t *testing.T) {
+	a := newAttack(new(sqsApiMock))
+	state := a.NewEmptyState()
+	_, err := a.Prepare(context.Background(), &state, newVisibilityRequest(43201))
+	require.Error(t, err)
+}
+
+func TestStartForwardsError(t *testing.T) {
+	api := new(sqsApiMock)
+	api.On("SetQueueAttributes", mock.Anything, mock.Anything).Return(nil, errors.New("boom"))
+	a := newAttack(api)
+	state := QueueVisibilityTimeoutAttackState{QueueUrl: "url", QueueName: "q", TargetVisibilityTimeout: 0}
+	_, err := a.Start(context.Background(), &state)
+	assert.Error(t, err)
+}

--- a/main.go
+++ b/main.go
@@ -151,6 +151,7 @@ func registerHandlers(ctx context.Context) {
 
 	if !cfg.DiscoveryDisabledSqs {
 		discovery_kit_sdk.Register(extsqs.NewQueueDiscovery(ctx))
+		action_kit_sdk.RegisterAction(extsqs.NewQueueVisibilityTimeoutAttack())
 	}
 
 	if !cfg.DiscoveryDisabledEventbridge {
@@ -205,6 +206,7 @@ func registerHandlers(ctx context.Context) {
 
 	if !cfg.DiscoveryDisabledDynamodb {
 		discovery_kit_sdk.Register(extdynamodb.NewTableDiscovery(ctx))
+		action_kit_sdk.RegisterAction(extdynamodb.NewTableThrottleAttack())
 	}
 
 	if !cfg.DiscoveryDisabledEks {


### PR DESCRIPTION
## Summary

Two new reversible attacks against discovery targets that already exist (SQS queues and DynamoDB tables). Both are designed so the AI advisor can pair them with reliability findings it surfaces from existing discovery attributes (e.g. *\"queue has no DLQ — consumer idempotency unvalidated\"* → trigger visibility shock; *\"PROVISIONED table without autoscaling\"* → trigger throttle).

## Attacks

### 1. SQS — Trigger AWS SQS Queue Visibility Timeout Change

\`ActionWithStop\`. Snapshot \`VisibilityTimeout\` at Prepare, \`SetQueueAttributes\` to user-provided value at Start, restore on Stop.

| Use case | Suggested value |
|----------|-----------------|
| Force premature redelivery → validate consumer idempotency | 0–5s |
| Stall redelivery → reveal stuck-message handling, DLQ routing | 30000–43200s |

Parameter range is the SQS hard max: 0..43200 (12h). If the queue has no explicit timeout, the SQS default of 30s is captured as the fallback for restore.

### 2. DynamoDB — Trigger AWS DynamoDB Table Throttle

\`ActionWithStop\`. PAY_PER_REQUEST tables rejected at Prepare. For PROVISIONED tables, snapshot table-level and per-GSI \`ReadCapacityUnits\`/\`WriteCapacityUnits\`, \`UpdateTable\` to user-provided low values at Start, restore on Stop.

Validates client retry/backoff against \`ProvisionedThroughputExceededException\`. If Application Auto Scaling is configured, it will eventually scale back up — the attack still exercises the throttle path during the autoscaler's reaction window (typically several minutes).

## IAM

Two single-permission additions:
- \`sqs:SetQueueAttributes\` (in the SQS block)
- \`dynamodb:UpdateTable\` (in the DynamoDB block)

Both documented in the README as optional for discovery-only deployments.

## Tests

15 new unit tests covering capture/restore/error paths for both attacks (6 SQS + 5 DynamoDB attack-specific + reused discovery mock extensions). \`go test ./...\` → 321 passed in 18 packages.

## Chart

Bumped to 2.2.26.

## Out of scope (separate PR)

The third attack we discussed, **EBS pause-volume-io via FIS**, is deferred. It needs:
- Dynamic FIS experiment template creation per volume (FIS doesn't support inline target overrides — the template must reference a specific volume ARN at create time, so we'd create + delete a one-shot template around each attack run)
- An operator-configured FIS IAM role (new env var)
- Additional IAM permissions: \`fis:CreateExperimentTemplate\`, \`fis:DeleteExperimentTemplate\`, \`iam:PassRole\`

Worth a separate design conversation given the FIS role config surface area.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l .\` clean
- [x] \`go test ./...\` — 321 unit tests pass
- [x] \`helm lint\` + \`helm unittest\` — 23/23 pass
- [ ] CI on this branch
- [ ] Smoke test on demo-develop: trigger SQS visibility shock on a test queue, trigger DynamoDB throttle on a PROVISIONED test table