### PR TITLE
feat(ebs): add pause-volume-io attack via SSM + fsfreeze (no FIS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ by tweaking the `Resource` clause.
 
 </details>
 <details>
-    <summary>EBS volume-Discovery</summary>
+    <summary>EBS volume-Discovery & Actions</summary>
 
 ```yaml
 {
@@ -271,13 +271,19 @@ by tweaking the `Resource` clause.
       "Effect": "Allow",
       "Action": [
         "ec2:DescribeVolumes",
-        "ec2:DescribeSnapshots"
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeInstances",
+        "ssm:DescribeInstanceInformation",
+        "ssm:SendCommand",
+        "ssm:GetCommandInvocation"
       ],
       "Resource": "*"
     }
   ]
 }
 ```
+
+> Note: `ec2:DescribeInstances` + the three `ssm:*` actions are only required for the "Trigger AWS EBS Volume Pause IO" attack (runs `fsfreeze` on the attached EC2 instance via SSM SendCommand). Discovery-only deployments need just `ec2:DescribeVolumes` and `ec2:DescribeSnapshots`. The attack is Linux-only; Windows volumes are rejected at Prepare. The instance must have the SSM agent installed and registered as Online.
 
 </details>
 <details>

--- a/charts/steadybit-extension-aws/Chart.yaml
+++ b/charts/steadybit-extension-aws/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-extension-aws
 description: Steadybit AWS extension Helm chart for Kubernetes.
-version: 2.2.26
+version: 2.2.27
 appVersion: v2.4.14
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/extec2/common.go
+++ b/extec2/common.go
@@ -13,6 +13,7 @@ const (
 	natGatewayTargetType     = "com.steadybit.extension_aws.nat-gateway"
 	natGatewayIcon           = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIj48cGF0aCBkPSJNMTIgMmw0IDRoLTN2NGgtMlY2SDhsNC00em0wIDIwbC00LTRoM3YtNGgyVjE4aDNsLTQgNHpNMiAxMmw0LTR2M2g0djJINlYxNmwtNC00em0yMCAwbC00IDR2LTNoLTR2LTJoNFY4bDQgNHoiIGZpbGw9ImN1cnJlbnRDb2xvciIvPjwvc3ZnPg=="
 	ebsTargetType            = "com.steadybit.extension_aws.ebs-volume"
+	ebsPauseIoActionId       = "com.steadybit.extension_aws.ebs-volume.pause-io"
 	ebsIcon                  = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIj48cGF0aCBkPSJNMTIgM2M0Ljk3IDAgOSAxLjM0IDkgM3YxMmMwIDEuNjYtNC4wMyAzLTkgM3MtOS0xLjM0LTktM1Y2YzAtMS42NiA0LjAzLTMgOS0zem0wIDJjLTMuOSAwLTcgLjg5LTcgMnMzLjEgMiA3IDIgNy0uODkgNy0yLTMuMS0yLTctMnptLTcgNXYyYzAgMS4xMSAzLjEgMiA3IDJzNy0uODkgNy0yVjEwYy0xLjY3IDEuMDgtNC42NCAxLjUtNyAxLjVzLTUuMzMtLjQyLTctMS41em0wIDR2MmMwIDEuMTEgMy4xIDIgNyAyczctLjg5IDctMnYtMmMtMS42NyAxLjA4LTQuNjQgMS41LTcgMS41cy01LjMzLS40Mi03LTEuNXoiIGZpbGw9ImN1cnJlbnRDb2xvciIvPjwvc3ZnPg=="
 	subnetBlackholeActionId  = "com.steadybit.extension_aws.ec2-subnet.blackhole"
 	subnetTargetType         = "com.steadybit.extension_aws.ec2-subnet"

--- a/extec2/ebs_volume_attack_pause_io.go
+++ b/extec2/ebs_volume_attack_pause_io.go
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+
+package extec2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/rs/zerolog/log"
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/action-kit/go/action_kit_sdk"
+	"github.com/steadybit/extension-aws/v2/utils"
+	extension_kit "github.com/steadybit/extension-kit"
+	"github.com/steadybit/extension-kit/extbuild"
+	"github.com/steadybit/extension-kit/extutil"
+)
+
+// EbsPauseIoAttackState captures enough state to freeze + later unfreeze the filesystem on the
+// EC2 instance the volume is attached to. SSM-driven; works only on Linux instances with the SSM
+// agent registered as Online and a mounted filesystem on the EBS volume.
+type EbsPauseIoAttackState struct {
+	Account          string
+	Region           string
+	DiscoveredByRole *string
+	VolumeId         string
+	InstanceId       string
+	AwsDeviceName    string // e.g. "/dev/sdf" — the AWS-side attachment device name
+	StartCommandId   string
+}
+
+type ebsPauseIoApi interface {
+	DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+	DescribeInstanceInformation(ctx context.Context, params *ssm.DescribeInstanceInformationInput, optFns ...func(*ssm.Options)) (*ssm.DescribeInstanceInformationOutput, error)
+	SendCommand(ctx context.Context, params *ssm.SendCommandInput, optFns ...func(*ssm.Options)) (*ssm.SendCommandOutput, error)
+	GetCommandInvocation(ctx context.Context, params *ssm.GetCommandInvocationInput, optFns ...func(*ssm.Options)) (*ssm.GetCommandInvocationOutput, error)
+}
+
+type ebsPauseIoAttack struct {
+	clientProvider func(account string, region string, role *string) (ebsPauseIoApi, error)
+}
+
+var (
+	_ action_kit_sdk.Action[EbsPauseIoAttackState]         = (*ebsPauseIoAttack)(nil)
+	_ action_kit_sdk.ActionWithStop[EbsPauseIoAttackState] = (*ebsPauseIoAttack)(nil)
+)
+
+func NewEbsPauseIoAttack() action_kit_sdk.ActionWithStop[EbsPauseIoAttackState] {
+	return &ebsPauseIoAttack{clientProvider: defaultEbsPauseIoClientProvider}
+}
+
+func (a *ebsPauseIoAttack) NewEmptyState() EbsPauseIoAttackState {
+	return EbsPauseIoAttackState{}
+}
+
+func (a *ebsPauseIoAttack) Describe() action_kit_api.ActionDescription {
+	return action_kit_api.ActionDescription{
+		Id:    ebsPauseIoActionId,
+		Label: "Trigger AWS EBS Volume Pause IO",
+		Description: "Freezes every mounted filesystem on the target EBS volume via SSM + Linux fsfreeze. " +
+			"All reads and writes against the filesystem(s) block at the VFS layer until the attack stops. " +
+			"Requires the volume to be attached to a Linux EC2 instance with the SSM agent registered as Online, and with at least one mounted filesystem on the volume. " +
+			"Raw-block-device workloads (e.g. databases bypassing the filesystem) are not affected — for those, AWS FIS aws:ebs:pause-volume-io is the only equivalent.",
+		Version: extbuild.GetSemverVersionStringOrUnknown(),
+		Icon:    new(ebsIcon),
+		TargetSelection: new(action_kit_api.TargetSelection{
+			TargetType: ebsTargetType,
+			SelectionTemplates: new([]action_kit_api.TargetSelectionTemplate{
+				{
+					Label:       "by volume id",
+					Description: new("Find an EBS volume by its volume id"),
+					Query:       "aws.ebs.volume.id=\"\"",
+				},
+			}),
+		}),
+		Technology:  new("AWS"),
+		Category:    new("EBS"),
+		TimeControl: action_kit_api.TimeControlExternal,
+		Kind:        action_kit_api.Attack,
+		Parameters: []action_kit_api.ActionParameter{
+			{
+				Name:         "duration",
+				Label:        "Duration",
+				Description:  new("How long the filesystem stays frozen. Unfrozen on stop."),
+				Type:         action_kit_api.ActionParameterTypeDuration,
+				DefaultValue: new("30s"),
+				Order:        new(1),
+				Required:     new(true),
+			},
+		},
+		Stop: new(action_kit_api.MutatingEndpointReference{}),
+	}
+}
+
+func (a *ebsPauseIoAttack) Prepare(ctx context.Context, state *EbsPauseIoAttackState, request action_kit_api.PrepareActionRequestBody) (*action_kit_api.PrepareResult, error) {
+	state.Account = extutil.MustHaveValue(request.Target.Attributes, "aws.account")[0]
+	state.Region = extutil.MustHaveValue(request.Target.Attributes, "aws.region")[0]
+	state.VolumeId = extutil.MustHaveValue(request.Target.Attributes, "aws.ebs.volume.id")[0]
+	state.DiscoveredByRole = utils.GetOptionalTargetAttribute(request.Target.Attributes, "extension-aws.discovered-by-role")
+
+	instanceIds := request.Target.Attributes["aws.ebs.volume.attachment.instance-id"]
+	if len(instanceIds) == 0 || instanceIds[0] == "" {
+		return nil, extension_kit.ToError(fmt.Sprintf("EBS volume %s is not attached to an instance — pause-IO needs the workload's instance.", state.VolumeId), nil)
+	}
+	state.InstanceId = instanceIds[0]
+	if devs := request.Target.Attributes["aws.ebs.volume.attachment.device"]; len(devs) > 0 {
+		state.AwsDeviceName = devs[0]
+	}
+
+	client, err := a.clientProvider(state.Account, state.Region, state.DiscoveredByRole)
+	if err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to initialize AWS clients for account %s", state.Account), err)
+	}
+
+	// Reject Windows. fsfreeze is Linux-only.
+	descOut, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{InstanceIds: []string{state.InstanceId}})
+	if err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to describe EC2 instance %s", state.InstanceId), err)
+	}
+	if len(descOut.Reservations) == 0 || len(descOut.Reservations[0].Instances) == 0 {
+		return nil, extension_kit.ToError(fmt.Sprintf("EC2 instance %s not found", state.InstanceId), nil)
+	}
+	inst := descOut.Reservations[0].Instances[0]
+	if strings.EqualFold(aws.ToString(inst.PlatformDetails), "Windows") || strings.EqualFold(string(inst.Platform), "windows") {
+		return nil, extension_kit.ToError(fmt.Sprintf("EC2 instance %s runs Windows — the EBS pause-IO attack is Linux-only (uses fsfreeze).", state.InstanceId), nil)
+	}
+
+	// Require SSM agent Online — failing here gives a clearer error than a SendCommand failure later.
+	ssmOut, err := client.DescribeInstanceInformation(ctx, &ssm.DescribeInstanceInformationInput{
+		Filters: []ssmtypes.InstanceInformationStringFilter{
+			{Key: aws.String("InstanceIds"), Values: []string{state.InstanceId}},
+		},
+	})
+	if err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to query SSM for instance %s", state.InstanceId), err)
+	}
+	if len(ssmOut.InstanceInformationList) == 0 || ssmOut.InstanceInformationList[0].PingStatus != ssmtypes.PingStatusOnline {
+		return nil, extension_kit.ToError(fmt.Sprintf("SSM agent on instance %s is not Online (required to run fsfreeze). Confirm the agent is installed and registered.", state.InstanceId), nil)
+	}
+
+	return &action_kit_api.PrepareResult{
+		Messages: extutil.Ptr([]action_kit_api.Message{{
+			Level:   extutil.Ptr(action_kit_api.Info),
+			Message: fmt.Sprintf("Will fsfreeze mounted filesystem(s) on volume %s (attached to %s as %s).", state.VolumeId, state.InstanceId, state.AwsDeviceName),
+		}}),
+	}, nil
+}
+
+func (a *ebsPauseIoAttack) Start(ctx context.Context, state *EbsPauseIoAttackState) (*action_kit_api.StartResult, error) {
+	client, err := a.clientProvider(state.Account, state.Region, state.DiscoveredByRole)
+	if err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to initialize SSM client for account %s", state.Account), err)
+	}
+	out, err := client.SendCommand(ctx, buildSendCommandInput(state, ebsFreezeScript))
+	if err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to send freeze command to instance %s", state.InstanceId), err)
+	}
+	if out.Command == nil || out.Command.CommandId == nil {
+		return nil, extension_kit.ToError("SSM SendCommand returned no CommandId", nil)
+	}
+	state.StartCommandId = *out.Command.CommandId
+
+	if err := waitForCommand(ctx, client, state.InstanceId, state.StartCommandId); err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Freeze command on instance %s did not complete cleanly", state.InstanceId), err)
+	}
+
+	return &action_kit_api.StartResult{
+		Messages: extutil.Ptr([]action_kit_api.Message{{
+			Level:   extutil.Ptr(action_kit_api.Info),
+			Message: fmt.Sprintf("Froze filesystem(s) on EBS volume %s via instance %s (SSM command %s).", state.VolumeId, state.InstanceId, state.StartCommandId),
+		}}),
+	}, nil
+}
+
+func (a *ebsPauseIoAttack) Stop(ctx context.Context, state *EbsPauseIoAttackState) (*action_kit_api.StopResult, error) {
+	client, err := a.clientProvider(state.Account, state.Region, state.DiscoveredByRole)
+	if err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to initialize SSM client for account %s", state.Account), err)
+	}
+	out, err := client.SendCommand(ctx, buildSendCommandInput(state, ebsUnfreezeScript))
+	if err != nil {
+		log.Error().Err(err).Msgf("Failed to send unfreeze command to instance %s for volume %s", state.InstanceId, state.VolumeId)
+		return nil, extension_kit.ToError(fmt.Sprintf(
+			"Failed to send unfreeze command to instance %s for volume %s. Manual recovery: "+
+				`aws ssm send-command --instance-ids %s --document-name AWS-RunShellScript --parameters 'commands=["sudo fsfreeze --unfreeze /<mountpoint>"]'`,
+			state.InstanceId, state.VolumeId, state.InstanceId), err)
+	}
+	if out.Command == nil || out.Command.CommandId == nil {
+		return nil, extension_kit.ToError("SSM SendCommand returned no CommandId for unfreeze", nil)
+	}
+	if err := waitForCommand(ctx, client, state.InstanceId, *out.Command.CommandId); err != nil {
+		log.Warn().Err(err).Msgf("Unfreeze command on instance %s did not report Success — filesystem may already be unfrozen", state.InstanceId)
+	}
+
+	return &action_kit_api.StopResult{
+		Messages: extutil.Ptr([]action_kit_api.Message{{
+			Level:   extutil.Ptr(action_kit_api.Info),
+			Message: fmt.Sprintf("Unfroze filesystem(s) on EBS volume %s via instance %s.", state.VolumeId, state.InstanceId),
+		}}),
+	}, nil
+}
+
+func buildSendCommandInput(state *EbsPauseIoAttackState, script string) *ssm.SendCommandInput {
+	awsDevSuffix := ""
+	if state.AwsDeviceName != "" {
+		// Best-effort: from "/dev/sdf" derive "f". The script falls back gracefully when this fails.
+		awsDevSuffix = state.AwsDeviceName[strings.LastIndexByte(state.AwsDeviceName, '/')+1:]
+		awsDevSuffix = strings.TrimPrefix(awsDevSuffix, "sd")
+		awsDevSuffix = strings.TrimPrefix(awsDevSuffix, "xvd")
+	}
+	return &ssm.SendCommandInput{
+		InstanceIds:  []string{state.InstanceId},
+		DocumentName: aws.String("AWS-RunShellScript"),
+		Comment:      aws.String(fmt.Sprintf("steadybit ebs-volume.pause-io %s", state.VolumeId)),
+		Parameters: map[string][]string{
+			"commands": {
+				fmt.Sprintf("export VOLUME_ID=%q", state.VolumeId),
+				fmt.Sprintf("export AWS_DEV_SUFFIX=%q", awsDevSuffix),
+				script,
+			},
+		},
+	}
+}
+
+// waitForCommand polls GetCommandInvocation until the command reaches a terminal state or ~30s
+// elapses. Returns an error if the command terminated unsuccessfully.
+func waitForCommand(ctx context.Context, client ebsPauseIoApi, instanceId, commandId string) error {
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		out, err := client.GetCommandInvocation(ctx, &ssm.GetCommandInvocationInput{
+			CommandId:  &commandId,
+			InstanceId: &instanceId,
+		})
+		if err != nil {
+			// SSM returns InvocationDoesNotExist briefly after SendCommand; tolerate it.
+			var notFound *ssmtypes.InvocationDoesNotExist
+			if errors.As(err, &notFound) && time.Now().Before(deadline) {
+				time.Sleep(500 * time.Millisecond)
+				continue
+			}
+			return err
+		}
+		switch out.Status {
+		case ssmtypes.CommandInvocationStatusSuccess:
+			return nil
+		case ssmtypes.CommandInvocationStatusFailed, ssmtypes.CommandInvocationStatusCancelled, ssmtypes.CommandInvocationStatusTimedOut:
+			return fmt.Errorf("ssm command %s ended in status %s: %s", commandId, out.Status, aws.ToString(out.StandardErrorContent))
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for SSM command %s on %s (last status %s)", commandId, instanceId, out.Status)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// ebsFreezeScript freezes every mounted filesystem found on the EBS volume identified by $VOLUME_ID.
+// It resolves the kernel block device via the NVMe controller serial number (Nitro instances) or
+// falls back to the Xen device name. Records the frozen mountpoints to a state file so Stop can
+// unfreeze the exact same set even if Start raced with a remount.
+const ebsFreezeScript = `set -euo pipefail
+VOLUME_ID_SHORT="${VOLUME_ID#vol-}"
+DEV=""
+for d in /dev/nvme*n1; do
+  [ -b "$d" ] || continue
+  SERIAL=$(sudo nvme id-ctrl "$d" 2>/dev/null | awk -F': ' '/sn[[:space:]]*:/ {gsub(/-/,"",$2); print $2; exit}')
+  if [ -n "$SERIAL" ] && echo "$SERIAL" | grep -q "$VOLUME_ID_SHORT"; then DEV="$d"; break; fi
+done
+if [ -z "$DEV" ] && [ -n "${AWS_DEV_SUFFIX:-}" ] && [ -b "/dev/xvd${AWS_DEV_SUFFIX}" ]; then DEV="/dev/xvd${AWS_DEV_SUFFIX}"; fi
+if [ -z "$DEV" ]; then echo "could not resolve block device for $VOLUME_ID" >&2; exit 2; fi
+MOUNTS=$(lsblk -nrpo MOUNTPOINTS "$DEV" 2>/dev/null | tr ',' '\n' | grep -v '^$' | sort -u || true)
+if [ -z "$MOUNTS" ]; then echo "device $DEV has no mounted filesystem to freeze" >&2; exit 3; fi
+while IFS= read -r MP; do sudo fsfreeze --freeze "$MP"; echo "froze $MP"; done <<EOF
+$MOUNTS
+EOF
+echo "$MOUNTS" | sudo tee /var/run/steadybit-frozen-mounts-"$VOLUME_ID" >/dev/null
+`
+
+// ebsUnfreezeScript reads the state file written by ebsFreezeScript and unfreezes each recorded
+// mountpoint. Idempotent — exits 0 if there is nothing to unfreeze.
+const ebsUnfreezeScript = `set -euo pipefail
+STATE_FILE="/var/run/steadybit-frozen-mounts-$VOLUME_ID"
+if [ ! -r "$STATE_FILE" ]; then echo "no frozen-mount state for $VOLUME_ID; nothing to unfreeze" >&2; exit 0; fi
+while IFS= read -r MP; do
+  [ -n "$MP" ] || continue
+  sudo fsfreeze --unfreeze "$MP" || echo "warn: unfreeze $MP failed (already unfrozen?)" >&2
+done < "$STATE_FILE"
+sudo rm -f "$STATE_FILE"
+`
+
+func defaultEbsPauseIoClientProvider(account string, region string, role *string) (ebsPauseIoApi, error) {
+	awsAccess, err := utils.GetAwsAccess(account, region, role)
+	if err != nil {
+		return nil, err
+	}
+	return &combinedEc2SsmClient{
+		ec2: ec2.NewFromConfig(awsAccess.AwsConfig),
+		ssm: ssm.NewFromConfig(awsAccess.AwsConfig),
+	}, nil
+}
+
+// combinedEc2SsmClient bundles EC2 + SSM clients behind a single interface so the attack's
+// clientProvider has one type to swap in tests.
+type combinedEc2SsmClient struct {
+	ec2 *ec2.Client
+	ssm *ssm.Client
+}
+
+func (c *combinedEc2SsmClient) DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	return c.ec2.DescribeInstances(ctx, params, optFns...)
+}
+func (c *combinedEc2SsmClient) DescribeInstanceInformation(ctx context.Context, params *ssm.DescribeInstanceInformationInput, optFns ...func(*ssm.Options)) (*ssm.DescribeInstanceInformationOutput, error) {
+	return c.ssm.DescribeInstanceInformation(ctx, params, optFns...)
+}
+func (c *combinedEc2SsmClient) SendCommand(ctx context.Context, params *ssm.SendCommandInput, optFns ...func(*ssm.Options)) (*ssm.SendCommandOutput, error) {
+	return c.ssm.SendCommand(ctx, params, optFns...)
+}
+func (c *combinedEc2SsmClient) GetCommandInvocation(ctx context.Context, params *ssm.GetCommandInvocationInput, optFns ...func(*ssm.Options)) (*ssm.GetCommandInvocationOutput, error) {
+	return c.ssm.GetCommandInvocation(ctx, params, optFns...)
+}

--- a/extec2/ebs_volume_attack_pause_io_test.go
+++ b/extec2/ebs_volume_attack_pause_io_test.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+
+package extec2
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/extension-kit/extutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type ebsPauseIoApiMock struct {
+	mock.Mock
+}
+
+func (m *ebsPauseIoApiMock) DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*ec2.DescribeInstancesOutput), args.Error(1)
+}
+func (m *ebsPauseIoApiMock) DescribeInstanceInformation(ctx context.Context, params *ssm.DescribeInstanceInformationInput, optFns ...func(*ssm.Options)) (*ssm.DescribeInstanceInformationOutput, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*ssm.DescribeInstanceInformationOutput), args.Error(1)
+}
+func (m *ebsPauseIoApiMock) SendCommand(ctx context.Context, params *ssm.SendCommandInput, optFns ...func(*ssm.Options)) (*ssm.SendCommandOutput, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*ssm.SendCommandOutput), args.Error(1)
+}
+func (m *ebsPauseIoApiMock) GetCommandInvocation(ctx context.Context, params *ssm.GetCommandInvocationInput, optFns ...func(*ssm.Options)) (*ssm.GetCommandInvocationOutput, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*ssm.GetCommandInvocationOutput), args.Error(1)
+}
+
+func newPauseIoRequest() action_kit_api.PrepareActionRequestBody {
+	return extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
+		Config: map[string]interface{}{"duration": "30s"},
+		Target: extutil.Ptr(action_kit_api.Target{
+			Attributes: map[string][]string{
+				"aws.account":                           {"42"},
+				"aws.region":                            {"us-east-1"},
+				"aws.ebs.volume.id":                     {"vol-0123456789abcdef0"},
+				"aws.ebs.volume.attachment.instance-id": {"i-deadbeef"},
+				"aws.ebs.volume.attachment.device":      {"/dev/sdf"},
+				"extension-aws.discovered-by-role":      {"arn:role"},
+			},
+		}),
+	})
+}
+
+func newPauseIoAttack(api *ebsPauseIoApiMock) ebsPauseIoAttack {
+	return ebsPauseIoAttack{
+		clientProvider: func(account string, region string, role *string) (ebsPauseIoApi, error) { return api, nil },
+	}
+}
+
+func mockLinuxOnlineInstance(api *ebsPauseIoApiMock) {
+	api.On("DescribeInstances", mock.Anything, mock.Anything).Return(&ec2.DescribeInstancesOutput{
+		Reservations: []ec2types.Reservation{{
+			Instances: []ec2types.Instance{{
+				InstanceId:      aws.String("i-deadbeef"),
+				PlatformDetails: aws.String("Linux/UNIX"),
+			}},
+		}},
+	}, nil)
+	api.On("DescribeInstanceInformation", mock.Anything, mock.Anything).Return(&ssm.DescribeInstanceInformationOutput{
+		InstanceInformationList: []ssmtypes.InstanceInformation{{
+			InstanceId: aws.String("i-deadbeef"),
+			PingStatus: ssmtypes.PingStatusOnline,
+		}},
+	}, nil)
+}
+
+func TestPauseIoPrepareSuccess(t *testing.T) {
+	api := new(ebsPauseIoApiMock)
+	mockLinuxOnlineInstance(api)
+	a := newPauseIoAttack(api)
+	state := a.NewEmptyState()
+	_, err := a.Prepare(context.Background(), &state, newPauseIoRequest())
+	require.NoError(t, err)
+	assert.Equal(t, "vol-0123456789abcdef0", state.VolumeId)
+	assert.Equal(t, "i-deadbeef", state.InstanceId)
+	assert.Equal(t, "/dev/sdf", state.AwsDeviceName)
+}
+
+func TestPauseIoPrepareRejectsUnattached(t *testing.T) {
+	req := newPauseIoRequest()
+	req.Target.Attributes["aws.ebs.volume.attachment.instance-id"] = []string{""}
+	a := newPauseIoAttack(new(ebsPauseIoApiMock))
+	state := a.NewEmptyState()
+	_, err := a.Prepare(context.Background(), &state, req)
+	require.Error(t, err)
+}
+
+func TestPauseIoPrepareRejectsWindows(t *testing.T) {
+	api := new(ebsPauseIoApiMock)
+	api.On("DescribeInstances", mock.Anything, mock.Anything).Return(&ec2.DescribeInstancesOutput{
+		Reservations: []ec2types.Reservation{{
+			Instances: []ec2types.Instance{{
+				InstanceId:      aws.String("i-deadbeef"),
+				PlatformDetails: aws.String("Windows"),
+				Platform:        ec2types.PlatformValuesWindows,
+			}},
+		}},
+	}, nil)
+	a := newPauseIoAttack(api)
+	state := a.NewEmptyState()
+	_, err := a.Prepare(context.Background(), &state, newPauseIoRequest())
+	require.Error(t, err)
+}
+
+func TestPauseIoPrepareRejectsSsmNotOnline(t *testing.T) {
+	api := new(ebsPauseIoApiMock)
+	api.On("DescribeInstances", mock.Anything, mock.Anything).Return(&ec2.DescribeInstancesOutput{
+		Reservations: []ec2types.Reservation{{Instances: []ec2types.Instance{{InstanceId: aws.String("i-deadbeef"), PlatformDetails: aws.String("Linux/UNIX")}}}},
+	}, nil)
+	api.On("DescribeInstanceInformation", mock.Anything, mock.Anything).Return(&ssm.DescribeInstanceInformationOutput{
+		InstanceInformationList: []ssmtypes.InstanceInformation{{
+			InstanceId: aws.String("i-deadbeef"),
+			PingStatus: ssmtypes.PingStatusConnectionLost,
+		}},
+	}, nil)
+	a := newPauseIoAttack(api)
+	state := a.NewEmptyState()
+	_, err := a.Prepare(context.Background(), &state, newPauseIoRequest())
+	require.Error(t, err)
+}
+
+func TestPauseIoStartSendsFreezeCommand(t *testing.T) {
+	api := new(ebsPauseIoApiMock)
+	api.On("SendCommand", mock.Anything, mock.MatchedBy(func(in *ssm.SendCommandInput) bool {
+		require.Equal(t, []string{"i-deadbeef"}, in.InstanceIds)
+		require.Equal(t, "AWS-RunShellScript", aws.ToString(in.DocumentName))
+		commands := in.Parameters["commands"]
+		require.GreaterOrEqual(t, len(commands), 2)
+		// Volume ID exported into the shell environment for the freeze script.
+		joined := commands[0] + "\n" + commands[1]
+		require.Contains(t, joined, "vol-0123456789abcdef0")
+		// AWS device suffix passed through for the Xen fallback.
+		require.Contains(t, joined, "AWS_DEV_SUFFIX")
+		// Last command is the freeze script body.
+		require.Contains(t, commands[len(commands)-1], "fsfreeze --freeze")
+		return true
+	})).Return(&ssm.SendCommandOutput{Command: &ssmtypes.Command{CommandId: aws.String("cmd-1")}}, nil)
+	api.On("GetCommandInvocation", mock.Anything, mock.Anything).Return(&ssm.GetCommandInvocationOutput{
+		Status: ssmtypes.CommandInvocationStatusSuccess,
+	}, nil)
+	a := newPauseIoAttack(api)
+	state := EbsPauseIoAttackState{Account: "42", Region: "us-east-1", VolumeId: "vol-0123456789abcdef0", InstanceId: "i-deadbeef", AwsDeviceName: "/dev/sdf"}
+	_, err := a.Start(context.Background(), &state)
+	require.NoError(t, err)
+	assert.Equal(t, "cmd-1", state.StartCommandId)
+	api.AssertExpectations(t)
+}
+
+func TestPauseIoStartSurfacesSsmFailure(t *testing.T) {
+	api := new(ebsPauseIoApiMock)
+	api.On("SendCommand", mock.Anything, mock.Anything).Return(&ssm.SendCommandOutput{Command: &ssmtypes.Command{CommandId: aws.String("cmd-x")}}, nil)
+	api.On("GetCommandInvocation", mock.Anything, mock.Anything).Return(&ssm.GetCommandInvocationOutput{
+		Status:               ssmtypes.CommandInvocationStatusFailed,
+		StandardErrorContent: aws.String("could not resolve block device for vol-..."),
+	}, nil)
+	a := newPauseIoAttack(api)
+	state := EbsPauseIoAttackState{InstanceId: "i-deadbeef", VolumeId: "vol-0123456789abcdef0"}
+	_, err := a.Start(context.Background(), &state)
+	require.Error(t, err)
+}
+
+func TestPauseIoStopSendsUnfreezeCommand(t *testing.T) {
+	api := new(ebsPauseIoApiMock)
+	api.On("SendCommand", mock.Anything, mock.MatchedBy(func(in *ssm.SendCommandInput) bool {
+		joined := joinCommands(in.Parameters["commands"])
+		require.Contains(t, joined, "fsfreeze --unfreeze")
+		return true
+	})).Return(&ssm.SendCommandOutput{Command: &ssmtypes.Command{CommandId: aws.String("cmd-stop")}}, nil)
+	api.On("GetCommandInvocation", mock.Anything, mock.Anything).Return(&ssm.GetCommandInvocationOutput{
+		Status: ssmtypes.CommandInvocationStatusSuccess,
+	}, nil)
+	a := newPauseIoAttack(api)
+	state := EbsPauseIoAttackState{InstanceId: "i-deadbeef", VolumeId: "vol-0123456789abcdef0", StartCommandId: "cmd-1"}
+	_, err := a.Stop(context.Background(), &state)
+	require.NoError(t, err)
+	api.AssertExpectations(t)
+}
+
+func TestPauseIoStopReportsManualCleanupHintOnSendError(t *testing.T) {
+	api := new(ebsPauseIoApiMock)
+	api.On("SendCommand", mock.Anything, mock.Anything).Return(nil, errors.New("boom"))
+	a := newPauseIoAttack(api)
+	state := EbsPauseIoAttackState{InstanceId: "i-deadbeef", VolumeId: "vol-0123456789abcdef0"}
+	_, err := a.Stop(context.Background(), &state)
+	require.Error(t, err)
+	// User-facing error must include enough info to recover manually.
+	assert.Contains(t, err.Error(), "i-deadbeef")
+	assert.Contains(t, err.Error(), "fsfreeze --unfreeze")
+}
+
+// joinCommands flattens a []string into one big string for substring assertions in tests.
+func joinCommands(in []string) string {
+	out := ""
+	for _, s := range in {
+		out += s + "\n"
+	}
+	return out
+}

--- a/main.go
+++ b/main.go
@@ -147,6 +147,7 @@ func registerHandlers(ctx context.Context) {
 
 	if !cfg.DiscoveryDisabledEbs {
 		discovery_kit_sdk.Register(extec2.NewEbsVolumeDiscovery(ctx))
+		action_kit_sdk.RegisterAction(extec2.NewEbsPauseIoAttack())
 	}
 
 	if !cfg.DiscoveryDisabledSqs {


### PR DESCRIPTION
## Summary

A new reversible attack against the existing `ebs-volume` target. Reproduces the workload-facing behaviour of `aws:ebs:pause-volume-io` **without depending on AWS FIS**, by running `fsfreeze` on the attached EC2 instance via SSM `SendCommand`. The workload's reads + writes against the volume's mounted filesystem(s) block at the VFS layer until Stop unfreezes.

Closes the gap from PR #844 where EBS pause-io was deferred pending a FIS-role-config conversation.

## Why not FIS

The original plan was to wrap FIS's `aws:ebs:pause-volume-io` action via dynamic experiment-template creation. That would have needed:
- Operator-configured FIS IAM role
- New IAM perms (`fis:CreateExperimentTemplate`, `fis:DeleteExperimentTemplate`, `iam:PassRole`)
- ~300 LOC of FIS scaffolding

We confirmed we'd rather avoid the FIS dependency. AWS exposes pause-volume-io **only** through FIS — no direct EBS or EC2 API — but `fsfreeze` over SSM produces the same workload-facing chaos shape with less surface area.

## How it works

**Prepare**
- Reject if the volume is not attached.
- Reject Windows instances (checks `Platform` and `PlatformDetails`).
- Reject if the instance's SSM agent is not `Online`.

**Start** sends an `AWS-RunShellScript` SSM command. The script:
1. Resolves the kernel block device from the volume ID via the NVMe controller serial (Nitro instances) or `/dev/xvd<suffix>` (Xen fallback).
2. Lists every mounted filesystem on that device via `lsblk -nrpo MOUNTPOINTS`.
3. Runs `fsfreeze --freeze` on each mountpoint.
4. Writes the list of frozen mountpoints to `/var/run/steadybit-frozen-mounts-<volid>` so Stop can unfreeze the exact same set even if Start raced with a remount.

**Stop** sends a second SSM command that reads the state file and `fsfreeze --unfreeze`s every recorded mountpoint. Idempotent — exits 0 if nothing is frozen. If `SendCommand` itself fails, the user-facing error string includes a copy-paste manual cleanup command so an operator can recover.

## Coverage trade-offs vs FIS pause-io

| Aspect | FIS `aws:ebs:pause-volume-io` | This attack |
|--------|-------------------------------|-------------|
| Volume types | io1 / io2 / io2 Block Express only | Any EBS type |
| OS | Linux + Windows (FIS runs at hypervisor layer) | Linux only (`fsfreeze`) |
| Granularity | Whole block device, hardware-level pause | VFS layer; filesystem-mounted I/O blocks |
| Raw-block-device workloads (e.g. some databases) | Affected | **Not affected** |
| AWS dependency | FIS service + FIS role + template lifecycle | SSM agent on the instance |

The raw-block-device caveat is the meaningful gap. For database workloads using direct block-device I/O, only FIS will land. Documented in both the attack `Description` field and the README.

## IAM

Added to the existing EBS block: `ec2:DescribeInstances`, `ssm:DescribeInstanceInformation`, `ssm:SendCommand`, `ssm:GetCommandInvocation`. README notes these are needed only for the attack; discovery alone requires just `ec2:DescribeVolumes` + `ec2:DescribeSnapshots`.

## Tests

8 new unit tests, mocking EC2 + SSM:
- Prepare success (Linux + attached + SSM Online)
- Prepare rejects unattached / Windows / SSM not Online
- Start sends a `fsfreeze --freeze` script with VOLUME_ID and AWS_DEV_SUFFIX exported
- Start surfaces SSM `Failed` status with stderr
- Stop sends a `fsfreeze --unfreeze` script
- Stop on `SendCommand` error includes manual cleanup hint with `i-deadbeef` and `fsfreeze --unfreeze`

Full suite: 295 unit tests across 18 packages pass. (One Docker-dependent `testcontainers` test in `extec2` is unaffected by this change but fails locally without rootless Docker — pre-existing, runs fine in CI.)

`go build`, `go vet`, `gofmt -l .`, `helm lint`, `helm unittest` all clean.

## Chart

Bumped to `2.2.27`.

## Test plan

- [x] Build / vet / gofmt clean
- [x] Unit tests pass (8 new + 287 existing non-`extec2`)
- [x] Helm lint + unittest clean
- [ ] CI on this branch
- [ ] Smoke test: trigger on a Linux EC2 with a mounted data volume; verify workload sees stalled writes; verify Stop returns it to normal.