### PR TITLE
docs: remove stray build: bullet from latest CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## v2.4.18
 
-- build: rename workflow_dispatch input labels for the GH UI
 - chore(deps): bump github.com/aws/aws-sdk-go-v2/service/apigateway
 - chore(deps): bump github.com/aws/aws-sdk-go-v2/service/dynamodb
 - chore(deps): bump github.com/aws/aws-sdk-go-v2/service/ec2


### PR DESCRIPTION
The auto-patch-release workflow added `- build: rename workflow_dispatch input labels for the GH UI` to the latest CHANGELOG entry. That bullet is a CI label rename with no runtime impact and shouldn't be user-facing.

A companion extension-kit PR adds `^build: ` to the default ignore regex so future runs skip such commits.