### PR TITLE
fix: prevent concurrent map writes crash in ECS SSM heartbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: guard the ECS SSM heartbeat map with a mutex to prevent a `concurrent map writes` crash when multiple ECS task attacks run concurrently
+
 ## v2.4.18
 
 - chore(deps): bump github.com/aws/aws-sdk-go-v2/service/apigateway

--- a/extecs/task_attack_ssm.go
+++ b/extecs/task_attack_ssm.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -81,7 +82,10 @@ type ssmCommandInvocation struct {
 	stepNameToOutput          string
 }
 
-var heartbeats = make(map[uuid.UUID]func())
+var (
+	heartbeatsMutex sync.Mutex
+	heartbeats      = make(map[uuid.UUID]func())
+)
 
 func newEcsTaskSsmAction(makeDescription func() action_kit_api.ActionDescription, invocation ssmCommandInvocation) action_kit_sdk.ActionWithStop[TaskSsmActionState] {
 	description := makeDescription()
@@ -330,7 +334,9 @@ func (e *ecsTaskSsmAction) startHeartbeat(state *TaskSsmActionState) {
 	}
 
 	heartbeatCtx, heartbeatCancel := context.WithTimeout(context.Background(), e.heartbeat.Timeout)
+	heartbeatsMutex.Lock()
 	heartbeats[state.ExecutionId] = heartbeatCancel
+	heartbeatsMutex.Unlock()
 
 	go func(parameters map[string][]string, ctx context.Context, cancel func()) {
 		client, err := e.clientProvider(state.Account, state.Region, state.DiscoveredByRole)
@@ -372,8 +378,13 @@ func (e *ecsTaskSsmAction) startHeartbeat(state *TaskSsmActionState) {
 }
 
 func (e *ecsTaskSsmAction) stopHeartbeat(state *TaskSsmActionState) {
-	if cancel, ok := heartbeats[state.ExecutionId]; ok {
+	heartbeatsMutex.Lock()
+	cancel, ok := heartbeats[state.ExecutionId]
+	if ok {
 		delete(heartbeats, state.ExecutionId)
+	}
+	heartbeatsMutex.Unlock()
+	if ok {
 		cancel()
 	}
 }


### PR DESCRIPTION
## Problem

The package-global `heartbeats` map in `extecs/task_attack_ssm.go` was accessed without synchronization:

- `startHeartbeat` **writes** the map (`heartbeats[state.ExecutionId] = heartbeatCancel`)
- `stopHeartbeat` **reads + deletes** (`heartbeats[state.ExecutionId]` / `delete(...)`)

Both run on separate per-request HTTP handler goroutines (action Start / Stop). Two ECS SSM network attacks (blackhole / dns / delay / loss — the actions that set `updateHeartbeatParameters`) with overlapping lifecycles race on this map.

Go aborts on `fatal error: concurrent map writes` / `concurrent map read and map write`. This is a **runtime fatal that bypasses `recover()`**, so it is *not* caught by the SDK's `PanicRecovery` middleware — it crashes the entire extension process and tears down all in-flight experiments. It is remotely triggerable by running two overlapping ECS network attacks.

## Fix

Guard all access to the `heartbeats` map with a dedicated `sync.Mutex`. The `cancel()` call in `stopHeartbeat` is invoked after releasing the lock to avoid holding it across the cancel.

## Testing

- `go build ./extecs/` passes
- `gofmt` clean